### PR TITLE
Add Control Adapter to LoRA conversion and multiplicative LoRA merging

### DIFF
--- a/tools/convert_control_adapter_to_lora.py
+++ b/tools/convert_control_adapter_to_lora.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""
+This script converts Control Adapters to standard LoRA format by distributing the multiplicative
+effect to specific linear layers within each transformer block, enabling use with standard LoRA
+merging tools.
+
+Usage: python convert_control_adapter_to_lora.py input_path output_path [--cohere | --mixtral N]
+
+---
+
+Control Adapters work by applying a multiplicative transform to the decoder layer's output:
+
+    decoder_output = decoder_output + (scale * B @ A @ decoder_output)
+
+This multiplicative effect can be distributed to specific linear layers within each block:
+
+1. LLAMA-TYPE MODELS - Target `mlp.down_proj` only:
+
+   In Llama-style architectures, the MLP processes the post-attention residual:
+
+   ```
+   residual = hidden_states
+   hidden_states = self.input_layernorm(hidden_states)
+   hidden_states, _ = self.self_attn(...)  # attention
+   hidden_states = residual + hidden_states
+
+   residual = hidden_states
+   hidden_states = self.post_attention_layernorm(hidden_states)
+   hidden_states = self.mlp(hidden_states)  # down_proj is the final layer here
+   hidden_states = residual + hidden_states
+   ```
+
+   Since down_proj is the final transformation before the residual addition, applying the
+   multiplicative LoRA here achieves a similar effect, though not identical due to `o_proj`
+   adding to the residual stream mid-layer.
+
+2. COHERE MODELS - Target both `self_attn.o_proj` AND `mlp.down_proj`:
+
+   Cohere runs attention and MLP in parallel, then sums both contributions:
+
+   ```
+   residual = hidden_states
+   hidden_states = self.input_layernorm(hidden_states)
+   hidden_states_attention, _ = self.self_attn(...)  # o_proj is final layer here
+   hidden_states_mlp = self.mlp(...)                 # down_proj is final layer here
+   hidden_states = residual + hidden_states_attention + hidden_states_mlp
+   ```
+
+   Since both paths contribute to the final residual, we need a multiplicative LoRA on
+   both `o_proj` and `down_proj` to exactly capture the full Control Adapter effect.
+
+3. MIXTRAL MODELS - Target all `block_sparse_moe.experts.{0..N-1}.w2`:
+
+   In Mixtral's MoE structure, `w2` serves the same role as `down_proj`:
+
+   ```
+   current_hidden_states = self.act_fn(self.w1(hidden_states)) * self.w3(hidden_states)
+   current_hidden_states = self.w2(current_hidden_states)  # w2 ≡ down_proj
+   ```
+
+   Each expert's `w2` is the final linear transformation, so applying multiplicative LoRA
+   to all expert `w2` layers achieves a similar effect to the Control Adapter, though not
+   identical due to `o_proj` adding to the residual stream mid-layer.
+
+    Due to the linearity of matrix operations, this works regardless of router weights or
+    top-k selection:
+
+       MoE(x) = sum of (weight_i * Expert_i(x))
+
+    Applying the same multiplicative effect to each Expert_i preserves this weighted sum.
+"""
+
+from pathlib import Path
+import argparse
+import json
+import re
+import safetensors
+import safetensors.torch
+import shutil
+import torch
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert Control Adapters to Multiplicative LoRA format")
+    parser.add_argument("input_path", type=str, help="The path to the Control Adapter directory.")
+    parser.add_argument("output_path", type=str, help="The path to the LoRA directory.")
+
+    # Model-specific options (mutually exclusive)
+    model_group = parser.add_mutually_exclusive_group()
+    model_group.add_argument("--cohere", action="store_true", help="Also target o_proj for Cohere models")
+    model_group.add_argument("--mixtral", type=int, metavar="N", help="Target experts.{0..N-1}.w2 for Mixtral models")
+
+    args = parser.parse_args()
+
+    input_path = Path(args.input_path)
+    output_path = Path(args.output_path)
+
+    # Create output directory
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    # Copy and modify adapter_config.json
+    config_filename = 'adapter_config.json'
+    if not (input_path / config_filename).exists():
+        raise FileNotFoundError(f"{config_filename} not found in input directory")
+
+    # Load, modify, and save config
+    with open(input_path / config_filename, 'r') as f:
+        config = json.load(f)
+
+    # Update target_modules based on model type
+    if args.mixtral:
+        config['target_modules'] = ["w2"]
+    elif args.cohere:
+        config['target_modules'] = ["down_proj", "o_proj"]
+    else:
+        config['target_modules'] = ["down_proj"]
+
+    with open(output_path / config_filename, 'w') as f:
+        json.dump(config, f, indent=2)
+
+    print(f"Updated and copied {config_filename}")
+
+    # Find adapter model file
+    adapter_filename = None
+    for filename in ['adapter_model.safetensors', 'adapter_model.bin']:
+        if (input_path / filename).exists():
+            adapter_filename = filename
+            break
+    else:
+        raise FileNotFoundError("No adapter_model.safetensors or adapter_model.bin found in input directory")
+
+    # Load the adapter weights
+    if Path(adapter_filename).suffix == '.safetensors':
+        state_dict = safetensors.torch.load_file(input_path / adapter_filename)
+    else:
+        state_dict = torch.load(input_path / adapter_filename, map_location='cpu', weights_only=True)
+
+    # Convert control adapters to multiplicative LoRA format
+    new_state_dict = {}
+
+    # Collect and sort control adapter keys by layer number
+    control_keys = list(state_dict.items())
+
+    # Sort control keys by layer number
+    def extract_layer_num(item):
+        key, _ = item
+        match = re.search(r'layers\.(\d+)\.control_([AB])\.weight', key)
+        if match:
+            return (int(match.group(1)), match.group(2))  # Sort by layer number, then A/B
+        return (float('inf'), '')  # Put unparseable keys at the end
+
+    control_keys.sort(key=extract_layer_num)
+
+    # Process control adapters in sorted order
+    print(f"Converting {len(control_keys)} control adapter tensors:")
+    for key, tensor in control_keys:
+        # Extract layer index from the key
+        # Pattern: base_model.model.model.layers.{layer_idx}.control_{A|B}.weight
+        match = re.search(r'layers\.(\d+)\.control_([AB])\.weight', key)
+        if match:
+            layer_idx = match.group(1)
+            adapter_type = match.group(2)
+
+            base_key = f"base_model.model.model.layers.{layer_idx}"
+            lora_suffix = f"lora_{adapter_type}.weight"
+
+            if args.mixtral:
+                # Target all experts' w2 for Mixtral models
+                for expert_idx in range(args.mixtral):
+                    new_key = f"{base_key}.block_sparse_moe.experts.{expert_idx}.w2.{lora_suffix}"
+                    new_state_dict[new_key] = tensor.clone()
+                    print(f"- '{key}' -> '{new_key}'")
+            else:
+                # Default: target mlp.down_proj
+                down_proj_key = f"{base_key}.mlp.down_proj.{lora_suffix}"
+                new_state_dict[down_proj_key] = tensor.clone()
+                print(f"- '{key}' -> '{down_proj_key}'")
+
+                if args.cohere:
+                    # Also target self_attn.o_proj for Cohere models
+                    o_proj_key = f"{base_key}.self_attn.o_proj.{lora_suffix}"
+                    new_state_dict[o_proj_key] = tensor.clone()
+                    print(f"- '{key}' -> '{o_proj_key}'")
+        else:
+            raise ValueError(f"Could not parse control adapter key: {key}")
+
+    print(f"Done (total tensors: {len(state_dict)} -> {len(new_state_dict)})")
+
+    # Save converted adapter weights
+    if Path(adapter_filename).suffix == '.safetensors':
+        safetensors.torch.save_file(new_state_dict, output_path / adapter_filename)
+    else:
+        torch.save(new_state_dict, output_path / adapter_filename)
+
+    print(f"Converted adapter saved to: '{output_path}'")
+
+if __name__ == "__main__":
+    main()

--- a/tools/merge_lora.py
+++ b/tools/merge_lora.py
@@ -14,14 +14,20 @@ parser = argparse.ArgumentParser()
 parser.add_argument("input_path", type=str, help="The path to the input directory.")
 parser.add_argument("lora_path", type=str, help="The path to the LoRA directory.")
 parser.add_argument("output_path", type=str, help="The path to the output directory.")
+parser.add_argument("--scale", type=float, default=1.0, help="Scale factor for LoRA merging (default: 1.0).")
+parser.add_argument("--multiplicative", action="store_true", help="Merge a multiplicative LoRA instead of an additive LoRA.")
+parser.add_argument("--inverse", action="store_true", help="Merge additive/multiplicative inverse of the LoRA.")
 parser.add_argument("--no-gpu", action="store_true", help="Use CPU for merging.")
 args = parser.parse_args()
+
+if not (0 < args.scale < 2):
+    parser.error("--scale must be in the range (0, 2)")
 
 input_path, lora_path, output_path = Path(args.input_path), Path(args.lora_path), Path(args.output_path)
 os.makedirs(output_path, exist_ok=True)
 
 lora_config = peft.LoraConfig.from_json_file(lora_path / 'adapter_config.json')
-scale = lora_config['lora_alpha'] / lora_config['r']
+scale = (lora_config['lora_alpha'] / lora_config['r']) * args.scale
 
 device = "cpu" if args.no_gpu else "cuda"
 
@@ -83,7 +89,25 @@ for shard in (pbar := tqdm(shards)):
                 pbar.set_description(f'found lora weights for {key}: {lora_A.size()}, {lora_B.size()}')
                 old_type = tensor.dtype
                 tensor = tensor.to(torch.float32)
-                tensor += scale * lora_B.to(torch.float32) @ lora_A.to(torch.float32)
+                lora_delta = scale * lora_B.to(torch.float32) @ lora_A.to(torch.float32)
+                if args.multiplicative:
+                    assert lora_delta.shape[0] == lora_delta.shape[1], \
+                        f"Multiplicative LoRA requires square delta matrix for {key}: got shape {lora_delta.shape}"
+                    assert lora_delta.shape[-1] == tensor.shape[-2], \
+                        f"Multiplicative LoRA dimension mismatch for {key}: {lora_delta.shape} vs {tensor.shape}"
+                    if args.inverse:
+                        identity = torch.eye(lora_delta.shape[0], device=lora_delta.device, dtype=torch.float32)
+                        inverse_matrix = torch.linalg.inv(identity + lora_delta)
+                        tensor = inverse_matrix @ tensor  # ie: tensor = (I + s * B @ A)^{-1} @ tensor
+                    else:
+                        tensor += lora_delta @ tensor  # same as: tensor = (I + s * B @ A) @ tensor
+                else:
+                    assert lora_delta.shape == tensor.shape, \
+                        f"Additive LoRA dimension mismatch for {key}: {lora_delta.shape} vs {tensor.shape}"
+                    if args.inverse:
+                        tensor -= lora_delta
+                    else:
+                        tensor += lora_delta
                 tensor = tensor.to(old_type)
             tensors[key] = tensor
         safetensors.torch.save_file(tensors, output_path / shard.name, metadata=metadata)


### PR DESCRIPTION
## Summary

This PR adds two new tools to support Control Adapter workflows:

1. `convert_control_adapter_to_lora.py` - Converts Control Adapters to standard LoRA format
2. Enhanced `merge_lora.py` - Adds multiplicative and inverse LoRA merging capabilities

## New Features

### Control Adapter Conversion (`convert_control_adapter_to_lora.py`)

Converts Control Adapters to multiplicative LoRA format by distributing the multiplicative effect to specific linear layers within transformer blocks:

- **Standard ("Llama-type") models**: Targets `mlp.down_proj` only
- **Cohere models** (--cohere): Targets both `self_attn.o_proj` and `mlp.down_proj `
- **Mixtral models** (--mixtral N): Targets all `block_sparse_moe.experts.{0..N-1}.w2`

The tool automatically updates `adapter_config.json` with the correct `target_modules` and preserves the original file format.

### Enhanced LoRA Merging (`merge_lora.py`)

Adds support for four merging modes:

- **Default**: Additive LoRA merging (eg: `tensor += delta`)
- **--inverse**: Subtractive LoRA merging (eg: `tensor -= delta`)
- **--multiplicative**: Multiplicative LoRA merging (eg: `tensor = (I + delta) @ tensor`)
- **--multiplicative --inverse**: Inverse multiplicative merging (eg: `tensor = (I + delta)^{-1} @ tensor`)

Additional improvements:
- **--scale** parameter for adjusting merge strength (range: 0 < scale < 2)
- Proper dimension validation for multiplicative operations
- Clear mathematical comments showing the operations

## Mathematical Background

Control Adapters work by applying multiplicative transforms to decoder layer outputs:

`decoder_output = decoder_output + (scale * B @ A @ decoder_output)`

This multiplicative effect can be distributed to specific linear layers before they contribute to the residual stream, enabling standard (**multiplicative**) LoRA merging to achieve the same or similar effects. For Cohere models with parallel attention/MLP paths, the distribution is mathematically exact, while for sequential architectures like Llama and Mixtral, it provides a close approximation.

## Usage Examples

Convert Control Adapters:
- Default: `python convert_control_adapter_to_lora.py input_dir output_dir`
- Cohere: `python convert_control_adapter_to_lora.py input_dir output_dir --cohere`
- Mixtral: `python convert_control_adapter_to_lora.py input_dir output_dir --mixtral 8`

Merge with different modes:
- Standard: `python merge_lora.py base_model lora_dir output_dir`
- Multiplicative: `python merge_lora.py base_model lora_dir output_dir --multiplicative`
- Half strength: `python merge_lora.py base_model lora_dir output_dir --scale 0.5`
- Inverse: `python merge_lora.py base_model lora_dir output_dir --multiplicative --inverse`

---

**NOTE**: A future update will look at saving the Control Adapter directly in `GGUF` format so it can be applied in a similar way to Control Vectors in `llama.cpp`. This will avoid the inexact merging for non-Cohere models and allow the scale factor and/or inversion to be applied at model load time. The key advantage is that users won't need to create a new merged model for each different scale or inversion setting - the same base model can be used with different Control Adapter parameters dynamically.