### PR TITLE
Remove neutral examples (`class 0`) and auxiliary loss functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,6 @@ Control Adapters are a new form of PEFT adapter that simultaneously applies mult
 - **Multiplicative**: Uses `h' = (I + scale * B @ A) @ h` transformations instead of additive `h' = h + (scale * B @ A) @ h` transformations like normal LoRA adapters
 - **Layer-wide**: Affects the entire residual stream rather than individual weight matrices
 - **Class-aware**: Supports positive (ie: `class 1`) and negative (ie: `class -1`, aka "unlearning") training examples, with negative examples using inverse transformations of the same adapter `h' = (I + scale * B @ A)^{-1} @ h` to suppress rather than enhance behaviors
-- **Optional neutral examples**: Can include neutral (ie: `class 0`) examples to prevent unwanted forgetting and provide additional regularization by isolating the specific behavioral "axis" being modified
 
 ### Relationship to Control Vectors
 
@@ -235,10 +234,6 @@ h' = (I + W)^{-1} @ h ≈ (I - W + higher_order_terms) @ h
 ```
 
 The inverse transformation uses a [Neumann series approximation](https://en.wikipedia.org/wiki/Neumann_series), allowing the same adapter parameters to both enhance desired behaviors (positive) and suppress undesired behaviors (negative) during training.
-
-#### For (optional) neutral examples (`class 0`):
-
-Neutral examples receive no transformation (`h' = h`) but contribute an auxiliary regularization loss that encourages the adapter to have minimal effect on these samples. This helps isolate the specific behavioral axis being modified and provides additional regularization beyond (decoupled) weight decay.
 
 ### Convergence Requirements and the need for Weight Decay
 
@@ -360,10 +355,9 @@ Contrastive training using LoRA-like (multiplicative) transformations on decoder
 
 ```toml
 use_control_adapters = true
-control_class0_lambda = 0.0    # Auxiliary loss weight for neutral examples (default: 0.0)
 ```
 
-Control Adapters support **class-aware training** with positive, negative, and (optional) neutral examples:
+Control Adapters support **class-aware training** with positive and negative examples:
 
 ```toml
 [[datasets]]
@@ -373,10 +367,6 @@ control_class = 1   # Enhance behaviors (default)
 [[datasets]]
 dataset_path = '/path/to/negative_examples/*.json'
 control_class = -1  # Suppress/unlearn behaviors
-
-[[datasets]]
-dataset_path = '/path/to/neutral_examples/*.json'
-control_class = 0   # Behavior we wish to preserve
 ```
 
 ### Configuration Structure

--- a/models/causal_lm_models.py
+++ b/models/causal_lm_models.py
@@ -69,7 +69,7 @@ class BaseCausalLMPipe(PipelineModel):
             **self._get_lm_head_kwargs()
         ))
 
-        result.append(LayerSpec(ComputeMetrics, self.training_config.get('control_class0_lambda', 0.0)))
+        result.append(LayerSpec(ComputeMetrics))
 
         return result
 

--- a/pipeline/dataloader.py
+++ b/pipeline/dataloader.py
@@ -134,10 +134,10 @@ class PipelineDataLoader:
         def collate_fn(examples):
             input_ids = torch.stack([ex['input_ids'] for ex in examples])
             attention_mask = torch.stack([ex['attention_mask'] for ex in examples])
-            labels = torch.stack([ex['labels'] for ex in examples])
             control_class = torch.tensor([ex['control_class'] for ex in examples], dtype=torch.int8)
+            labels = torch.stack([ex['labels'] for ex in examples])
 
-            return ((input_ids, attention_mask, labels, control_class), None)
+            return ((input_ids, attention_mask, control_class, labels), None)
 
         self.dataloader = DataLoader(
             self.dataset,

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -275,8 +275,6 @@ class Trainer:
         """Write all metrics to tensorboard."""
         self.tb_writer.add_scalar(f'{prefix}/loss', metrics[0].mean().item(), step)
         self.tb_writer.add_scalar(f'{prefix}/top1_accuracy', metrics[1].mean().item(), step)
-        if len(metrics) > 2:
-            self.tb_writer.add_scalar(f'{prefix}/aux_loss', metrics[2].mean().item(), step)
 
     def _print_eval_progress(self, step, current_loss, last_loss=None):
         """Print evaluation progress with optional percentage change."""

--- a/utils/dataset_utils.py
+++ b/utils/dataset_utils.py
@@ -76,10 +76,6 @@ def slice_into_sequences(
                 attention_mask = torch.ones(sequence_len, dtype=torch.int8)
                 labels = input_ids.clone()
 
-                # The class-0 samples must not contribute to the CE loss
-                if control_class == 0:
-                    labels[:] = -100
-
                 # Mask out BOS tokens in labels (if they exist)
                 if tokenizer.bos_token_id is not None:
                     labels[labels == tokenizer.bos_token_id] = -100
@@ -97,8 +93,8 @@ def slice_into_sequences(
                 all_sequences.append({
                     'input_ids': input_ids,
                     'attention_mask': attention_mask,
-                    'labels': labels,
-                    'control_class': control_class
+                    'control_class': control_class,
+                    'labels': labels
                 })
 
                 sequence_count += 1
@@ -114,8 +110,8 @@ def slice_into_sequences(
     result_dataset = datasets.Dataset.from_dict({
         'input_ids': [seq['input_ids'] for seq in all_sequences],
         'attention_mask': [seq['attention_mask'] for seq in all_sequences],
-        'labels': [seq['labels'] for seq in all_sequences],
-        'control_class': [seq['control_class'] for seq in all_sequences]
+        'control_class': [seq['control_class'] for seq in all_sequences],
+        'labels': [seq['labels'] for seq in all_sequences]
     })
     result_dataset.set_format(type='torch')
 
@@ -198,7 +194,7 @@ def load_datasets(config, tokenizer):
             max_sequences = dataset_config.get('max_sequences', sys.maxsize)
             assert max_sequences > 0, f"max_sequences must be positive, got {max_sequences}"
             control_class = dataset_config.get('control_class', 1)
-            assert control_class in [-1, 0, 1], f"control_class must be -1, 0, or 1, got {control_class}"
+            assert control_class in [-1, 1], f"control_class must be -1 or 1, got {control_class}"
             drop_tails = dataset_config.get('drop_tails', False)
             dataset = load_single_dataset(
                 dataset_config['dataset_path'],


### PR DESCRIPTION
### Description:
Simplifies Control Adapters to support only binary classification with positive (`class 1`) and negative (`class -1`) examples. This change removes the complexity of neutral examples and their associated auxiliary loss computation while maintaining the core multiplicative adapter functionality.

### Changes:
- Remove support for `control_class = 0` (neutral examples)
- Remove auxiliary loss computation and `control_class0_lambda` parameter
- Reorder pipeline tuple elements (`control_class` now precedes labels)
- Update documentation and configuration examples
- Simplify metrics computation and logging

**NOTE**: Due to the reordering of tuple elements in the data pipeline, any previously cached/preprocessed datasets will need to be deleted and regenerated to match the new format.