### PR TITLE
Add Symmetry Regulariser for Control-Adapter Training

### DIFF
--- a/models/causal_lm_models.py
+++ b/models/causal_lm_models.py
@@ -69,7 +69,7 @@ class BaseCausalLMPipe(PipelineModel):
             **self._get_lm_head_kwargs()
         ))
 
-        result.append(LayerSpec(ComputeMetrics))
+        result.append(LayerSpec(ComputeMetrics, self.training_config.get('symmetry_lambda', 0.0)))
 
         return result
 

--- a/models/pipeline_layers.py
+++ b/models/pipeline_layers.py
@@ -183,11 +183,11 @@ class ComputeMetrics(nn.Module):
 
         def class_ce(mask):
             # Clone & mask labels; skip call if class absent (avoids Triton assert)
-            lab = shift_labels.clone()
-            lab[~mask] = -100
-            if torch.count_nonzero(lab != -100) == 0:
+            masked_labels = shift_labels.clone()
+            masked_labels[~mask] = -100
+            if torch.count_nonzero(masked_labels != -100) == 0:
                 return logits.new_zeros(())  # scalar 0.0, no grad
-            return fast_cross_entropy_loss(logits, lab)  # mean over class tokens
+            return fast_cross_entropy_loss(logits, masked_labels)  # mean over class tokens
 
         ce_pos = class_ce(mask_pos)
         ce_neg = class_ce(mask_neg)

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -275,6 +275,10 @@ class Trainer:
         """Write all metrics to tensorboard."""
         self.tb_writer.add_scalar(f'{prefix}/loss', metrics[0].mean().item(), step)
         self.tb_writer.add_scalar(f'{prefix}/top1_accuracy', metrics[1].mean().item(), step)
+        if (len(metrics) > 2):
+            self.tb_writer.add_scalar(f'{prefix}/loss_ce_pos', metrics[2].mean().item(), step)
+            self.tb_writer.add_scalar(f'{prefix}/loss_ce_neg', metrics[3].mean().item(), step)
+            self.tb_writer.add_scalar(f'{prefix}/loss_symmetry_penalty', metrics[4].mean().item(), step)
 
     def _print_eval_progress(self, step, current_loss, last_loss=None):
         """Print evaluation progress with optional percentage change."""


### PR DESCRIPTION
Control Adapters are trained with paired positive (`class +1`) and negative (`class -1`) examples in the same parameter block `W = BA`. Ideally, the transformation `W` should affect the two classes equally and oppositely. In practice, nothing in the loss function enforces this symmetry, so some directions of `W` can become "one-sided".

This PR introduces an **optional scalar penalty** that pushes the class-conditioned cross-entropies towards equality, thereby encouraging `W` and `-W` to remain "balanced".

---

### Mathematics:

For each class $c \in \{+1, -1\}$, let:

$$
CE_c = E[-\log Q(x)] = H(P_c) + KL(P_c || Q)
$$

Since $H(P_c)$ is constant, the **difference**:

$$
\Delta = CE_{+1} - CE_{-1}
$$

measures the gap between the two KL divergences. Perfect symmetry means $\Delta = 0$.

The dimension-less **relative imbalance**:

$$
\rho = \frac{\Delta}{S}, \quad S = CE_{+1} + CE_{-1}
$$

is scale-free and matters equally when the model is poor (large CEs) or good (small CEs).

We minimize:

$$
L = CE_{+1} + CE_{-1} + \lambda \rho^2
$$

with user-supplied weight $\lambda$. Setting $\lambda = 0$ recovers the original objective (*EDIT: Actually it doesn't mathematically due to the unweighted sum and difference, but we have a special case to avoid for now - see notes below*)

---

### Changes:

- `ComputeMetrics` now accepts `symmetry_lambda` and computes the penalty.
- Penalty is applied *only* when both classes are present in the micro-batch.
- If `symmetry_lambda = 0` **or** every sample has `control_class = 1`, training is identical to the previous version.
- Monitor `loss_ce_pos`, `loss_ce_neg`, and `loss_symmetry_penalty` in TensorBoard.


---

### Notes:

- This relies on the batches being reasonably evenly distributed - it might be worth enforcing this in `DistributedBatchSampler` later... Looks like a lot of hassle to do this, so probably best to just try to use fairly large batches to start with.
- We use the unweighted sum and difference to give both classes equal weight in each batch (and thus any degenerate batches that contains tokens from only one control class, will still have the penalty applied)... Ensure the batches are large enough to avoid this for now and fix later if needed.
- The way we compute this via masked calls to `fast_cross_entropy_loss` might need looking at too (preferably at the same time as `DistributedBatchSampler` so we can somehow lay the `class +1` and `class -1` samples out sensibly).
- This will likely allow `lora_weight_decay` to be reduced quite significantly due to the added regularisation effect of `symmetry_lambda`.