### PR TITLE
Added LoRA-specific `max-norm` regularisation via a 1st order approximation

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -5,6 +5,7 @@ DEFAULT_EPS = 1e-6
 
 # LoRA (and Control Adapter) specific defaults
 DEFAULT_LORA_WEIGHT_DECAY = 0.0
+DEFAULT_LORA_MAX_NORM = 0.0
 DEFAULT_LORA_DROPOUT = 0.0
 
 # Evaluation defaults


### PR DESCRIPTION
The code gets applied after the LoRA-specific decoupled weight decay inside of `_apply_lora_weight_decay_local`.

I explained the maths in the comments so no need to repeat here... It should work quite well as we should never be able to get too far away from `W` such that the 1st order approximation isn't good enough.