### PR TITLE
Normalize loss/metrics by global token count to remove GA padding bias

### DIFF
--- a/kernels/cross_entropy_loss.py
+++ b/kernels/cross_entropy_loss.py
@@ -281,8 +281,5 @@ def fast_cross_entropy_loss(logits, labels):
         labels.view(-1),
     )
 
-    n_items = torch.count_nonzero(labels != -100)
-    assert n_items > 0, "All labels are masked (-100), so n_items denominator will be zero"
-
-    return loss.sum() / n_items
+    return loss.sum(dtype=torch.float32)
 pass

--- a/training/model_factory.py
+++ b/training/model_factory.py
@@ -37,7 +37,7 @@ def patch_decoder_layer_control_adapter(module):
     """Create a new forward method that includes Control Adapter logic for DecoderLayerPipe."""
 
     def control_adapter_forward(inputs):
-        hidden_states, attention_mask, cos, sin, cache_position, control_classes, labels = inputs
+        hidden_states, attention_mask, cos, sin, cache_position, control_classes, labels, n_tokens = inputs
 
         # Shift control_classes for causal LM: [control_classes[1:], 0_padding]
         batch_size, seq_len = control_classes.shape
@@ -90,7 +90,7 @@ def patch_decoder_layer_control_adapter(module):
         # Cast adapter contribution back to original dtype and add to the residual stream
         result = layer_output + adapter_output.to(torch_result_dtype)
 
-        return (result, attention_mask, cos, sin, cache_position, control_classes, labels)
+        return (result, attention_mask, cos, sin, cache_position, control_classes, labels, n_tokens)
 
     return control_adapter_forward
 

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -140,10 +140,8 @@ class Trainer:
         self.model_engine.micro_batches = orig_micro_batches
         eval_metrics = [torch.cat(metric_list) for metric_list in all_metrics]
 
-        # Log evaluation metrics
-        self._write_metrics('eval', eval_metrics)
-
-        return self._extract_loss(eval_metrics)
+        # Log evaluation metrics and return the mean loss
+        return  self._write_metrics('eval', eval_metrics)
 
     # Private helper methods
     def _calculate_eval_steps(self, steps_per_epoch, evals_per_epoch):
@@ -434,14 +432,13 @@ class Trainer:
             local_stats = self._apply_lora_regularization_local(model, config, lr)
         return self._aggregate_statistics(local_stats)
 
-    def _extract_loss(self, metrics):
-        """Extract loss (first metric) as a scalar value."""
-        return metrics[0].mean().item()
-
     def _write_metrics(self, prefix, metrics):
-        """Write all metrics to tensorboard."""
-        self._write_scalar_metric(f'{prefix}/loss', metrics[0].mean().item())
-        self._write_scalar_metric(f'{prefix}/accuracy_top1', metrics[1].mean().item())
+        """Write all metrics to tensorboard and return mean loss."""
+        loss = metrics[0].mean().item()
+        accuracy_top1 = metrics[1].mean().item()
+        self._write_scalar_metric(f'{prefix}/loss', loss)
+        self._write_scalar_metric(f'{prefix}/accuracy_top1', accuracy_top1)
+        return loss
 
     def _write_scalar_metric(self, name, value):
         """Log scalar value to tensorboard using current global step."""


### PR DESCRIPTION
• Compute CE as an fp32 sum in the kernel; defer normalization
• Pass global token count (n_tokens = DP × GAS × seq_len × batch_per_rank) from dataloader, broadcast through all pipeline stages
• In ComputeMetrics:
• loss_sum = sum CE over non-masked tokens
• accuracy_top1_sum = sum over correct non-masked tokens
• Normalize both by the same n_tokens for consistent scaling
• Engine aggregation:
• Collapse per-micro outputs into per-step constants so mean() yields the per-step value
• Unifies train/eval logging without special handling in Trainer
• Dataloader:
• Compute n_tokens per step (avoid double-counting GAS)
• split_batch broadcasts scalar n_tokens to micros
• Control Adapters: thread n_tokens through patched forward
• Improves numerical stability (fp32 accumulation) and ensures gradients are invariant to padding/masking and gradient accumulation settings