### PR TITLE
Simplification of Control Adapter Architecture

### DIFF
--- a/analyze_control_adapters.py
+++ b/analyze_control_adapters.py
@@ -1,53 +1,163 @@
 #!/usr/bin/env python3
 """
-Analyze Control Adapter matrix norms and statistical properties.
+Analyze Control Adapter matrix norms and convergence properties.
 
 OVERVIEW:
-    Analyzes Control Adapter matrices W = Q @ diag(λ) @ Q^T where:
-    • Q ∈ ℝ^{H×r} should have semi-orthogonal columns (enforced by training regularizer)
-    • λ ∈ ℝ^r contains per-direction eigenvalues
+    Analyzes Control Adapter matrices W = s·(B @ A) where:
+    • A ∈ ℝ^{r×H} is the down-projection (control_A.weight)
+    • B ∈ ℝ^{H×r} is the up-projection (control_B.weight)
+    • s = lora_alpha / r is the LoRA scaling factor
 
-    Computes true matrix norms via SVD and compares to λ-based approximations
-    (which are exact only when Q is perfectly orthogonal).
+    Computes matrix norms via SVD to verify convergence requirements for
+    the Neumann series approximation used during training.
 
 USAGE:
     python analyze_control_adapters.py --adapter /path/to/adapter [--no-gpu]
 
 OUTPUT COLUMNS:
-    ‖Q^TQ-I_r‖_F²       : Squared orthogonality error of Q
-                          • 0 = perfect, max = r(r-1) = 240 for rank-16
-                          • Good: < 1.0, Excellent: < 0.5, Poor: > 2.0
+    ‖W‖₂                : Spectral norm (largest singular value)
+                          • Must be < 1 for Neumann series convergence
+                          • Target < 0.25 for optimal 1st-order approximation
 
-    ‖W‖_F, ‖W‖_2, ‖W‖_* : True matrix norms from SVD (truncated to rank r)
+    ‖W‖_F               : Frobenius norm (‖singular values‖₂)
+                          • Cheaper to monitor during training
+                          • Target < 0.25·√r
+
+    ‖W‖_F/√r            : Normalized Frobenius norm for rank-independent comparison
+
+    ‖W‖₂/‖W‖_F          : Ratio showing singular value distribution
+                          • = 1/√r for uniform distribution
+                          • = 1 for rank-1 matrix (all energy in one direction)
 
     erank(W)            : Effective rank = (‖W‖_*)²/(‖W‖_F)² ∈ [1, r]
-                          • Measures singular value distribution flatness
-                          • Good: Close to r (e.g., 15+ out of 16), Poor: << r (rank collapse)
+                          • High ≈ balanced singular values
+                          • Low ≈ rank collapse
 
     κ(W)                : Condition number = σ_max/σ_min
-                          • Good: < 100, Poor: > 1000, ∞ = rank deficient
+                          • Good: < 100, Poor: > 1000
 
-    ‖Ŵ‖_2, ‖Ŵ‖_*        : λ-based approximations assuming perfect orthogonality:
-                          • ‖Ŵ‖_2 = max(|λ|), ‖Ŵ‖_* = sum(|λ|)
+    Target              : ✓ if ‖W‖₂ < 0.25 (optimal approximation)
 
-    ε_‖Ŵ‖_2, ε_‖Ŵ‖_*    : Signed approximation errors = (approx - true) / true
-                          • Positive = overestimation (expected with non-orthogonal Q)
-                          • Good: < 5%, Poor: > 20%
+    Stable              : ✓ if ‖W‖₂ < 1 (convergence guaranteed)
 
 SUMMARY STATISTICS:
-    Shows mean [min, max] across all layers.
+    Shows min/max/mean across all layers, plus convergence status.
 """
 
 from pathlib import Path
+from typing import Dict
 import argparse
+import json
+import math
+import re
+import safetensors.torch
 import torch
 
-from training.control_adapters import (
-    apply_control_adapter_transform,
-    load_control_adapter_weights,
-    parse_control_adapter_keys,
-)
-from utils.utils import format_percentage
+def load_control_adapter_weights(adapter_path: Path) -> Dict[str, torch.Tensor]:
+    """Load Control Adapter weights from safetensors or .bin files."""
+    # Try adapter_model.safetensors first
+    st_path = adapter_path / 'adapter_model.safetensors'
+    if st_path.exists():
+        return safetensors.torch.load_file(st_path, device='cpu')
+
+    # Try adapter_model.bin
+    bin_path = adapter_path / 'adapter_model.bin'
+    if bin_path.exists():
+        return torch.load(bin_path, map_location='cpu', weights_only=True)
+
+    raise FileNotFoundError(f"No adapter_model.safetensors or adapter_model.bin found in {adapter_path}")
+
+def parse_control_adapter_keys(state_dict: Dict[str, torch.Tensor]) -> Dict[int, Dict[str, torch.Tensor]]:
+    """Parse control adapter state dict into layer -> {A, B} mapping."""
+    control_adapters = {}
+
+    for key, tensor in state_dict.items():
+        match = re.search(r'layers\.(\d+)\.control_(A|B)', key)
+        if match:
+            layer_idx = int(match.group(1))
+            param_type = match.group(2)
+
+            if layer_idx not in control_adapters:
+                control_adapters[layer_idx] = {}
+            control_adapters[layer_idx][param_type] = tensor
+
+    return control_adapters
+
+def load_adapter_config(adapter_path: Path) -> Dict:
+    """Load adapter configuration."""
+    config_path = adapter_path / 'adapter_config.json'
+    if not config_path.exists():
+        raise FileNotFoundError(f"adapter_config.json not found in {adapter_path}")
+
+    with open(config_path, 'r') as f:
+        config = json.load(f)
+
+    if 'lora_alpha' not in config or 'r' not in config:
+        raise ValueError("adapter_config.json must contain 'lora_alpha' and 'r'")
+
+    return config
+
+def analyze_layer_norms(A: torch.Tensor, B: torch.Tensor, lora_scale: float, rank: int, device: str) -> Dict[str, float]:
+    """Analyze norms for a single Control Adapter layer.
+
+    Args:
+        A: control_A.weight tensor [adapter_rank, hidden_size]
+        B: control_B.weight tensor [hidden_size, adapter_rank]
+        lora_scale: lora_alpha / rank scaling factor
+        rank: adapter rank
+        device: device for computation ('cpu' or 'cuda')
+
+    Returns:
+        Dictionary of statistics including norms, effective rank, condition number, etc.
+    """
+    A_gpu = A.to(device=device, dtype=torch.float32)
+    B_gpu = B.to(device=device, dtype=torch.float32)
+
+    # Compute composite matrix W = lora_scale * (B @ A)
+    # B is [hidden_size, adapter_rank], A is [adapter_rank, hidden_size]
+    # Result is [hidden_size, hidden_size]
+    W = lora_scale * (B_gpu @ A_gpu)
+
+    # Use SVD for accurate norm calculations
+    # full_matrices=False gives min(M, N) singular values
+    _, S, _ = torch.linalg.svd(W, full_matrices=False)
+
+    # Truncate to rank (in case of numerical artifacts)
+    k = min(rank, S.numel())
+    assert k > 0, f"No singular values computed (rank={rank}, S.numel()={S.numel()})"
+
+    S_truncated = S[:k]
+
+    # Compute norms from singular values
+    spectral_norm = S_truncated[0].item()  # ‖W‖₂ = σ_max
+    min_singular_value = S_truncated[-1].item()  # σ_min (within rank)
+    nuclear_norm = torch.sum(S_truncated).item()  # ‖W‖_* = Σσ_i
+    frobenius_norm = torch.norm(S_truncated).item()  # ‖W‖_F = ‖σ‖₂
+
+    # Effective rank: erank = (‖W‖_*)² / (‖W‖_F)²
+    effective_rank = (nuclear_norm ** 2) / (frobenius_norm ** 2) if frobenius_norm > 1e-10 else 0.0
+
+    # Condition number: κ = σ_max / σ_min
+    condition_number = spectral_norm / min_singular_value if min_singular_value > 1e-10 else float('inf')
+
+    sqrt_rank = math.sqrt(rank)
+
+    # Guard division by frobenius_norm
+    spectral_over_frobenius = spectral_norm / frobenius_norm if frobenius_norm > 1e-10 else 0.0
+
+    return {
+        'spectral_norm': spectral_norm,
+        'frobenius_norm': frobenius_norm,
+        'nuclear_norm': nuclear_norm,
+        'effective_rank': effective_rank,
+        'condition_number': condition_number,
+        'sqrt_rank': sqrt_rank,
+        'frobenius_over_sqrt_rank': frobenius_norm / sqrt_rank,
+        'spectral_over_frobenius': spectral_over_frobenius,
+        'converges': spectral_norm < 1.0,
+        'meets_guideline': frobenius_norm < 0.25 * sqrt_rank,
+        'optimal_spectral': spectral_norm < 0.25
+    }
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Analyze Control Adapter norm constraints")
@@ -55,18 +165,31 @@ if __name__ == "__main__":
     parser.add_argument("--no-gpu", action="store_true", help="Use CPU for SVD computation")
     args = parser.parse_args()
 
-    # Device selection logic
+    # Device selection
     device = "cpu" if args.no_gpu or not torch.cuda.is_available() else "cuda"
 
     adapter_path = Path(args.adapter)
 
-    # Load weights
-    _, state_dict = load_control_adapter_weights(adapter_path)
+    # Load configuration and weights
+    config = load_adapter_config(adapter_path)
+    state_dict = load_control_adapter_weights(adapter_path)
+
+    lora_alpha = config['lora_alpha']
+    lora_rank = config['r']
+    lora_scale = lora_alpha / lora_rank
 
     print("Control Adapter Analysis")
     print("========================")
-    print(f"Path   : '{adapter_path}'")
-    print(f"Device : '{device}'")
+    print(f"Path       : '{adapter_path}'")
+    print(f"Device     : '{device}'")
+    print(f"LoRA Alpha : {lora_alpha}")
+    print(f"LoRA Rank  : {lora_rank}")
+    print(f"LoRA Scale : {lora_scale:.4f}")
+    print()
+    print("Convergence Requirements:")
+    print(f"  • ‖W‖₂ < 1.00   (Neumann series converges)")
+    print(f"  • ‖W‖₂ < 0.25   (optimal 1st-order approximation: error ≤ 1-2%)")
+    print(f"  • ‖W‖_F < {0.25 * math.sqrt(lora_rank):.3f}  (monitoring target: 0.25·√r)")
     print()
 
     # Parse layers
@@ -78,112 +201,59 @@ if __name__ == "__main__":
 
     # Analyze each layer
     results = []
-    print(f"{'Layer':<6} {'‖QᵀQ-Iᵣ‖_F²':<12} {'‖W‖_F':<8} {'‖W‖_2':<8} {'‖W‖_*':<8} "
-          f"{'erank(W)':<10} {'κ(W)':<8} "
-          f"{'‖Ŵ‖_2':<8} {'‖Ŵ‖_*':<8} {'ε_‖Ŵ‖_2':<10} {'ε_‖Ŵ‖_*':<10}")
-    print("-" * 104)
+    print(f"{'Layer':<6} {'‖W‖₂':<8} {'‖W‖_F':<8} {'‖W‖_F/√r':<10} {'‖W‖₂/‖W‖_F':<12} "
+          f"{'erank(W)':<10} {'κ(W)':<8} {'Target':<8} {'Stable':<8}")
+    print("-" * 84)
 
     for layer_idx in sorted(layer_data.keys()):
-        # Check that both Q and S exist for this layer
-        if 'Q' not in layer_data[layer_idx] or 'S' not in layer_data[layer_idx]:
+        if 'A' not in layer_data[layer_idx] or 'B' not in layer_data[layer_idx]:
             continue
 
-        Q = layer_data[layer_idx]['Q'].to(torch.float32)
-        S = layer_data[layer_idx]['S'].to(torch.float32)
+        A = layer_data[layer_idx]['A']
+        B = layer_data[layer_idx]['B']
 
-        rank = int(S.numel())
-        assert Q.ndim == 2 and Q.shape[1] == rank, f"Shape mismatch: Q has {Q.shape[1]} cols, S has {rank} entries"
-
-        with torch.no_grad():
-            # Compute the full matrix W = Q @ diag(λ) @ Q^T, with λ = exp(S) - 1
-            W = apply_control_adapter_transform(Q, S, device=device, inverse=False)
-
-            # Run SVD to get true singular values
-            svals = torch.linalg.svdvals(W).cpu()
-
-            # Truncate to the actual rank of the control adapter
-            svals = svals[:rank]
-
-            # True norms from SVD (using truncated singular values)
-            spectral_norm = svals[0].item()  # ||W||_2 = max singular value
-            min_singular_value = svals[-1].item()  # minimum singular value within rank
-            nuclear_norm = torch.sum(svals).item()  # ||W||_* = sum of singular values
-            frobenius_norm = torch.norm(svals).item()  # ||W||_F = ||singular values||_2
-
-            # Effective rank
-            effective_rank = (nuclear_norm ** 2) / (frobenius_norm ** 2) if frobenius_norm > 1e-10 else 0.0
-
-            # Condition number
-            condition_number = spectral_norm / min_singular_value if min_singular_value > 1e-10 else float('inf')
-
-            # Approximated norms (assuming perfect orthogonality): λ = exp(S) - 1
-            lambda_vec = torch.expm1(S)
-            spectral_norm_approx = torch.max(torch.abs(lambda_vec)).item()
-            nuclear_norm_approx = torch.sum(torch.abs(lambda_vec)).item()
-
-            # Signed ratio errors (for % formatting) - shows direction of bias
-            spectral_error_ratio = (spectral_norm_approx - spectral_norm) / abs(spectral_norm) if abs(spectral_norm) > 1e-10 else 0.0
-            nuclear_error_ratio = (nuclear_norm_approx - nuclear_norm) / abs(nuclear_norm) if abs(nuclear_norm) > 1e-10 else 0.0
-
-            # Orthogonality measure: ||Q^T @ Q - I_r||_F^2
-            QTQ = Q.t() @ Q
-            I_r = torch.eye(Q.size(1), dtype=Q.dtype, device=Q.device)
-            orthogonality_error = (torch.norm(QTQ - I_r, p='fro') ** 2).item()
-
-        stats = {
-            'spectral_norm': spectral_norm,
-            'nuclear_norm': nuclear_norm,
-            'frobenius_norm': frobenius_norm,
-            'effective_rank': effective_rank,
-            'condition_number': condition_number,
-            'spectral_norm_approx': spectral_norm_approx,
-            'nuclear_norm_approx': nuclear_norm_approx,
-            'spectral_error_ratio': spectral_error_ratio,
-            'nuclear_error_ratio': nuclear_error_ratio,
-            'orthogonality_error': orthogonality_error
-        }
+        stats = analyze_layer_norms(A, B, lora_scale, lora_rank, device)
         results.append(stats)
 
         print(f"{layer_idx:<6} "
-              f"{stats['orthogonality_error']:<12.3f} "
-              f"{stats['frobenius_norm']:<8.3f} "
               f"{stats['spectral_norm']:<8.3f} "
-              f"{stats['nuclear_norm']:<8.3f} "
+              f"{stats['frobenius_norm']:<8.3f} "
+              f"{stats['frobenius_over_sqrt_rank']:<10.3f} "
+              f"{stats['spectral_over_frobenius']:<12.3f} "
               f"{stats['effective_rank']:<10.1f} "
               f"{stats['condition_number']:<8.1f} "
-              f"{stats['spectral_norm_approx']:<8.3f} "
-              f"{stats['nuclear_norm_approx']:<8.3f} "
-              f"{format_percentage(stats['spectral_error_ratio'], 3):<10} "
-              f"{format_percentage(stats['nuclear_error_ratio'], 3):<10}")
+              f"{'✓' if stats['optimal_spectral'] else '✗':<8} "
+              f"{'✓' if stats['converges'] else '✗':<8}")
 
     # Summary statistics
     if results:
         spectral_norms = [r['spectral_norm'] for r in results]
-        nuclear_norms = [r['nuclear_norm'] for r in results]
         frobenius_norms = [r['frobenius_norm'] for r in results]
+        frobenius_ratios = [r['frobenius_over_sqrt_rank'] for r in results]
         effective_ranks = [r['effective_rank'] for r in results]
         condition_numbers = [r['condition_number'] for r in results]
-        orthogonality_errors = [r['orthogonality_error'] for r in results]
-        spectral_error_ratios = [r['spectral_error_ratio'] for r in results]
-        nuclear_error_ratios = [r['nuclear_error_ratio'] for r in results]
-        print()
 
+        converging_layers = sum(1 for r in results if r['converges'])
+        optimal_layers = sum(1 for r in results if r['optimal_spectral'])
+
+        print()
         layer_count_digits = len(str(len(results)))
-        print(f"Summary statistics for {len(results)} layers (mean [min, max]):")
-        print("=" * (49 + layer_count_digits))
-        print(f"Orthogonality (‖QᵀQ-Iᵣ‖_F²) : {sum(orthogonality_errors)/len(orthogonality_errors):.3f} "
-              f"[{min(orthogonality_errors):.3f}, {max(orthogonality_errors):.3f}]")
-        print(f"True Frobenius norm (‖W‖_F) : {sum(frobenius_norms)/len(frobenius_norms):.3f} "
-              f"[{min(frobenius_norms):.3f}, {max(frobenius_norms):.3f}]")
-        print(f"True spectral norm (‖W‖_2)  : {sum(spectral_norms)/len(spectral_norms):.3f} "
-              f"[{min(spectral_norms):.3f}, {max(spectral_norms):.3f}]")
-        print(f"True nuclear norm (‖W‖_*)   : {sum(nuclear_norms)/len(nuclear_norms):.3f} "
-              f"[{min(nuclear_norms):.3f}, {max(nuclear_norms):.3f}]")
-        print(f"Effective rank (erank(W))   : {sum(effective_ranks)/len(effective_ranks):.1f} "
-              f"[{min(effective_ranks):.1f}, {max(effective_ranks):.1f}]")
-        print(f"Condition number (κ(W))     : {sum(condition_numbers)/len(condition_numbers):.1f} "
-              f"[{min(condition_numbers):.1f}, {max(condition_numbers):.1f}]")
-        print(f"Spectral norm error (ε_2)   : {format_percentage(sum(spectral_error_ratios)/len(spectral_error_ratios))} "
-              f"[{format_percentage(min(spectral_error_ratios))}, {format_percentage(max(spectral_error_ratios))}]")
-        print(f"Nuclear norm error (ε_*)    : {format_percentage(sum(nuclear_error_ratios)/len(nuclear_error_ratios))} "
-              f"[{format_percentage(min(nuclear_error_ratios))}, {format_percentage(max(nuclear_error_ratios))}]")
+        print(f"Summary statistics for {len(results)} layers (min / max / mean):")
+        print("=" * (58 + layer_count_digits))
+        print(f"Spectral norm (‖W‖₂)          : {min(spectral_norms):.3f} / {max(spectral_norms):.3f} / {sum(spectral_norms)/len(spectral_norms):.3f}")
+        print(f"Frobenius norm (‖W‖_F)        : {min(frobenius_norms):.3f} / {max(frobenius_norms):.3f} / {sum(frobenius_norms)/len(frobenius_norms):.3f}")
+        print(f"Normalized Frobenius (‖W‖_F/√r) : {min(frobenius_ratios):.3f} / {max(frobenius_ratios):.3f} / {sum(frobenius_ratios)/len(frobenius_ratios):.3f}")
+        print(f"Effective rank (erank(W))     : {min(effective_ranks):.1f} / {max(effective_ranks):.1f} / {sum(effective_ranks)/len(effective_ranks):.1f}")
+        print(f"Condition number (κ(W))       : {min(condition_numbers):.1f} / {max(condition_numbers):.1f} / {sum(condition_numbers)/len(condition_numbers):.1f}")
+        print()
+        print(f"Stable layers (‖W‖₂ < 1):      {converging_layers}/{len(results)} ({100*converging_layers/len(results):.1f}%)")
+        print(f"Optimal layers (‖W‖₂ < 0.25):  {optimal_layers}/{len(results)} ({100*optimal_layers/len(results):.1f}%)")
+
+        if max(spectral_norms) >= 1.0:
+            print()
+            print("⚠️  WARNING: Some layers have ‖W‖₂ ≥ 1, which may cause Neumann series divergence!")
+
+        if min(spectral_norms) >= 0.25:
+            print("⚠️  WARNING: All layers exceed the optimal ‖W‖₂ < 0.25 target!")
+        elif max(spectral_norms) >= 0.25:
+            print("⚠️  WARNING: Some layers exceed the optimal ‖W‖₂ < 0.25 target!")

--- a/constants.py
+++ b/constants.py
@@ -3,9 +3,6 @@ DEFAULT_BETA1 = 0.9
 DEFAULT_BETA2 = 0.99
 DEFAULT_EPS = 1e-6
 
-# NOTE: This must be > 0 to maintain semi-orthogonality, and <= 0.5 to avoid overshooting (see code comment).
-DEFAULT_CONTROL_ADAPTER_GAMMA = 0.5
-
 # Evaluation defaults
 DEFAULT_EVALS_PER_EPOCH = 10
 DEFAULT_EVAL_FRACTION = 0.01

--- a/constants.py
+++ b/constants.py
@@ -14,3 +14,8 @@ DEFAULT_MAX_CHECKPOINTS = 3
 # Misc constants
 DEEPSPEED_TIMEOUT_HOURS = 6
 DATASET_MAP_BATCH_SIZE = 10
+
+# For the inverse approximation (I + W)^{-1}, when ‖W‖₂ ≲ 0.2–0.3, the 1st-order truncation
+# error O(‖W‖₂²) ≤ 1–2%. Going to order 2 halves the error (O(‖W‖₂³)) but doubles the matmul cost.
+# Order 3+ yields less than 0.1% improvement in the intended ‖W‖₂ norm range.
+NEUMANN_SERIES_ORDER = 2

--- a/constants.py
+++ b/constants.py
@@ -18,4 +18,4 @@ DATASET_MAP_BATCH_SIZE = 10
 # For the inverse approximation (I + W)^{-1}, when ‖W‖₂ ≲ 0.2–0.3, the 1st-order truncation
 # error O(‖W‖₂²) ≤ 1–2%. Going to order 2 halves the error (O(‖W‖₂³)) but doubles the matmul cost.
 # Order 3+ yields less than 0.1% improvement in the intended ‖W‖₂ norm range.
-NEUMANN_SERIES_ORDER = 2
+NEUMANN_SERIES_ORDER = 1

--- a/control_adapter_to_lora.py
+++ b/control_adapter_to_lora.py
@@ -1,19 +1,21 @@
 #!/usr/bin/env python3
 """
-Convert Control Adapters to an exact additive LoRA.
+Convert Control Adapters to an additive LoRA via SVD approximation.
 
-We exploit the low-rank structure:
-  DeltaW = (Q diag(lambda) Q^T) @ W = (Q diag(lambda)) @ (Q^T W)
-So LoRA B = Q diag(lambda), LoRA A = Q^T W, retaining the original adapter rank.
+Computes the effect of the control adapter on model weights:
+  Forward:  delta = W @ weight, where W = B @ A (assumes lora_alpha = r, so scale = 1)
+  Inverse:  delta = ((I + W)^{-1} - I) @ weight
+
+Then approximates delta via SVD: delta ≈ B_lora @ A_lora
 
 USAGE:
     python control_adapter_to_lora.py --base /path/to/base_model --adapter /path/to/control_adapter --output /path/to/out_dir
-                                      [--inverse] [--cohere | --mixtral N]
+                                      [--inverse] [--rank R] [--no-gpu] [--cohere | --mixtral N]
 """
 
 from pathlib import Path
 import argparse
-import safetensors
+import json
 import safetensors.torch
 import torch
 
@@ -26,13 +28,28 @@ from training.control_adapters import (
     load_model_weights,
 )
 
+def load_adapter_config(adapter_path: Path):
+    """Load adapter configuration to get lora_alpha and rank."""
+    config_path = adapter_path / 'adapter_config.json'
+    if not config_path.exists():
+        raise FileNotFoundError(f"adapter_config.json not found in {adapter_path}")
+
+    with open(config_path, 'r') as f:
+        config = json.load(f)
+
+    if 'lora_alpha' not in config or 'r' not in config:
+        raise ValueError("adapter_config.json must contain 'lora_alpha' and 'r'")
+
+    return config
+
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Convert Control Adapters to exact Additive LoRA (no SVD)")
+    parser = argparse.ArgumentParser(description="Convert Control Adapters to Additive LoRA via SVD")
     parser.add_argument("--base", required=True, type=str, help="Path to the base model directory")
     parser.add_argument("--adapter", required=True, type=str, help="Path to the Control Adapter directory")
     parser.add_argument("--output", required=True, type=str, help="Path to the output LoRA directory")
+    parser.add_argument("--rank", type=int, default=None, help="Override SVD rank (default: use adapter rank)")
     parser.add_argument("--no-gpu", action="store_true", help="Use CPU for computation")
-    parser.add_argument("--inverse", action="store_true", help="Use exact inverse delta: (I + W)^{-1} - I")
+    parser.add_argument("--inverse", action="store_true", help="Use exact inverse: ((I + W)^{-1} - I) @ weight")
     model_group = parser.add_mutually_exclusive_group()
     model_group.add_argument("--cohere", action="store_true", help="Also target o_proj for Cohere models")
     model_group.add_argument("--mixtral", type=int, metavar="N", help="Target experts.{0..N-1}.w2 for Mixtral models")
@@ -47,69 +64,115 @@ if __name__ == "__main__":
     output_path = Path(args.output)
     output_path.mkdir(parents=True, exist_ok=True)
 
+    # Load configuration
+    adapter_config = load_adapter_config(control_adapter_path)
+    lora_alpha = adapter_config['lora_alpha']
+    adapter_rank = adapter_config['r']
+
+    # Verify input adapter has lora_alpha == r (scale = 1)
+    assert lora_alpha == adapter_rank, \
+        f"Input adapter must have lora_alpha == r (got lora_alpha={lora_alpha}, r={adapter_rank})"
+
+    # Determine output rank
+    output_rank = args.rank if args.rank is not None else adapter_rank
+
+    # Copy and patch adapter config
     copy_and_patch_adapter_config(control_adapter_path, output_path, args)
 
+    # Update output config to match output rank (with lora_alpha = r for scale = 1)
+    output_config_path = output_path / 'adapter_config.json'
+    with open(output_config_path, 'r') as f:
+        output_config = json.load(f)
+    output_config['r'] = output_rank
+    output_config['lora_alpha'] = output_rank
+    with open(output_config_path, 'w') as f:
+        json.dump(output_config, f, indent=2)
+
+    # Load weights
     control_keys, control_state_dict = load_control_adapter_weights(control_adapter_path)
     model_weights = load_model_weights(base_model_path)
 
     lora_state_dict = {}
-
     layer_data = parse_control_adapter_keys(control_state_dict)
 
     print()
-    print(f"Converting {len(control_keys)//2} layers ({len(control_keys)} tensors) (device='{device}'):")
+    print(f"Converting {len(layer_data)} layers (device='{device}', output_rank={output_rank}):")
+    print()
 
     for layer_idx in sorted(layer_data.keys()):
-        if 'Q' not in layer_data[layer_idx] or 'S' not in layer_data[layer_idx]:
+        if 'A' not in layer_data[layer_idx] or 'B' not in layer_data[layer_idx]:
             continue
 
-        Q = layer_data[layer_idx]['Q']
-        S = layer_data[layer_idx]['S']
+        A = layer_data[layer_idx]['A']
+        B = layer_data[layer_idx]['B']
+        old_dtype = A.dtype
 
-        with torch.no_grad():
-            old_type = Q.dtype
-            m, r = Q.shape
+        # Move to device as float32 for computation
+        A_gpu = A.to(device=device, dtype=torch.float32)
+        B_gpu = B.to(device=device, dtype=torch.float32)
 
-            # Move to device as float32 for compute
-            Q_d = Q.to(device=device, dtype=torch.float32)
-            S_d = S.to(device=device, dtype=torch.float32)
+        # Compute composite matrix W = B @ A (scale = 1 due to lora_alpha == r)
+        W = B_gpu @ A_gpu  # [hidden_size, hidden_size]
 
-            # Forward or exact inverse delta coefficients
-            # forward:  lambda = exp(S) - 1
-            # inverse:  lambda' = exp(-S) - 1 = -lambda/(1+lambda)
-            coeff = torch.expm1(-S_d) if args.inverse else torch.expm1(S_d)  # [r]
+        target_keys = generate_model_weight_keys(layer_idx, args)
 
-            # Common B factor per layer: B = Q diag(coeff)  => scale columns of Q by coeff
-            B_common = Q_d * coeff.unsqueeze(0)  # [m, r]
+        for target_key in target_keys:
+            if target_key not in model_weights:
+                continue
 
-            target_keys = generate_model_weight_keys(layer_idx, args)
+            # Load base weight
+            weight = model_weights[target_key].to(device=device, dtype=torch.float32)
 
-            for target_key in target_keys:
-                if target_key not in model_weights:
-                    continue
+            # Compute delta based on forward or inverse mode
+            if args.inverse:
+                # Exact inverse: delta = ((I + W)^{-1} - I) @ weight
+                I = torch.eye(W.size(0), device=device, dtype=torch.float32)
+                W_inv = torch.linalg.inv(I + W)
+                delta = (W_inv - I) @ weight
+            else:
+                # Forward: delta = W @ weight
+                delta = W @ weight
 
-                # Load base weight and compute A = Q^T W
-                W = model_weights[target_key].to(device=device, dtype=torch.float32)  # [m, n]
-                A = Q_d.T @ W  # [r, n]
+            # SVD approximation of delta
+            U, S, Vt = torch.linalg.svd(delta, full_matrices=False)
 
-                # Cast back to original dtype and CPU for saving
-                A_out = A.to(dtype=old_type, device='cpu')
-                B_out = B_common.to(dtype=old_type, device='cpu')
+            # Move back to CPU for rank selection
+            U, S, Vt = U.cpu(), S.cpu(), Vt.cpu()
 
-                a_key = generate_lora_key(layer_idx, target_key, 'A', args)
-                b_key = generate_lora_key(layer_idx, target_key, 'B', args)
-                lora_state_dict[a_key] = A_out
-                lora_state_dict[b_key] = B_out
+            # Determine actual rank to use
+            max_rank = min(output_rank, len(S))
+            if max_rank == 0:
+                continue
 
-                base_key = f"base_model.model.model.layers.{layer_idx}"
-                print()
-                print(f"- Layer {layer_idx}, retained rank {r}")
-                print(f"  -- '{base_key}.control_Q' + '{base_key}.control_S'")
-                print(f"  -> '{a_key}' + '{b_key}'")
+            sqrt_S = torch.sqrt(S[:max_rank])
 
-    print()
+            # Construct LoRA matrices: delta ≈ B_lora @ A_lora
+            A_lora = torch.diag(sqrt_S) @ Vt[:max_rank,:]  # [max_rank, output_size]
+            B_lora = U[:,:max_rank] @ torch.diag(sqrt_S)  # [hidden_size, max_rank]
+
+            # Cast to original dtype
+            A_lora = A_lora.to(old_dtype)
+            B_lora = B_lora.to(old_dtype)
+
+            # Generate keys and save
+            a_key = generate_lora_key(layer_idx, target_key, 'A', args)
+            b_key = generate_lora_key(layer_idx, target_key, 'B', args)
+            lora_state_dict[a_key] = A_lora
+            lora_state_dict[b_key] = B_lora
+
+            # Compute variance explained
+            total_variance = torch.sum(S ** 2)
+            explained_variance = torch.sum(S[:max_rank] ** 2)
+            variance_pct = 100 * explained_variance / total_variance if total_variance > 1e-10 else 0.0
+
+            base_key = f"base_model.model.model.layers.{layer_idx}"
+            print(f"- Layer {layer_idx}: SVD rank {max_rank}/{len(S)}, {variance_pct:.1f}% variance explained")
+            print(f"  -- '{base_key}.control_A.weight' + '{base_key}.control_B.weight'")
+            print(f"  -> '{a_key}' + '{b_key}'")
+            print()
+
     print(f"Done (total tensors: {len(control_state_dict)} -> {len(lora_state_dict)})")
+    print()
 
     safetensors.torch.save_file(lora_state_dict, output_path / 'adapter_model.safetensors')
-    print()
     print(f"Converted LoRA adapter saved to: '{output_path}'")

--- a/docs/ControlAdapters.md
+++ b/docs/ControlAdapters.md
@@ -93,7 +93,7 @@ python lora_to_gguf.py \
 
 ### What are Control Adapters?
 
-Control Adapters are a parameter-efficient fine-tuning method that provides **multiplicative control** over LLM behaviour. Unlike additive methods like LoRA that add `W + BA` to weights, Control Adapters apply multiplicative transformations to the residual delta (the change produced by decoder layers) of the form `(I + Q diag(λ) Q^T) × delta` (ie: parameterised as a [spectral decomposition of a real symmetric matrix](https://en.wikipedia.org/wiki/Eigendecomposition_of_a_matrix#Real_symmetric_matrices)).
+Control Adapters are a parameter-efficient fine-tuning method that provides **multiplicative control** over LLM behaviour. Unlike additive methods like LoRA that add `W + BA` to weights, Control Adapters apply multiplicative transformations to the residual delta (the change produced by decoder layers) of the form `(I + W) × delta`, where `W = BA` is a low-rank matrix similar to LoRA.
 
 ### Development and Motivation
 
@@ -101,17 +101,18 @@ Control Adapters evolved through several iterations to address fundamental chall
 
 The initial concept was a "multiplicative LoRA" using general transformations `(I + AB^T) × delta`, but this proved too unconstrained and destabilised models. Adding bidirectional control with separate positive/negative classes helped, but using negated gradients for the negative class caused training instability due to the unbounded nature of maximising cross-entropy loss.
 
-Early approaches explored first-order Neumann series approximations `(I - AB^T) × delta` for inverse transformations, but required keeping eigenvalues within a narrow range (`|λ| < 0.3`) for mathematical validity, making regularisation difficult. General factorisations like `Q diag(λ) P^T` offered more flexibility but disrupted critical model behaviours like end-of-line handling.
+Early approaches explored first-order Neumann series approximations `(I - AB^T) × delta` for inverse transformations, but required keeping spectral norms within a narrow range (`‖W‖₂ < 0.3`) for mathematical validity, making regularisation difficult. Attempts to use spectral decompositions `Q diag(λ) Q^T` with log-parameterisation provided exact inverses but required complex orthogonality constraints and disrupted critical model behaviours.
 
-The current approach using symmetric matrices `Q diag(λ) Q^T` with log-parameterisation `λ = exp(S) - 1` emerged as the solution, balancing expressive power with the constraints necessary for stable language model training.
+The current approach using standard LoRA-like factorisation `W = BA` with Neumann series inverse approximation emerged as the solution, balancing expressive power with the constraints necessary for stable language model training while maintaining simple, familiar parameterisation.
 
 ### Key Features
 
-- **Bidirectional Control**: Forward transformations (class `+1`) and inverse transformations (class `-1`) using the same parameters
+- **Bidirectional Control**: Forward transformations (class `+1`) and inverse approximations (class `-1`) using the same parameters
 - **Class-Conditional**: Different behaviour based on control classes (`+1`, `-1`)
 - **Randomised Regularisation**: Datasets assigned to class `0` are mapped randomly to class `±1` during preprocessing
-- **Parameter Efficient**: Only `r×(H+1)` parameters per transformed layer (where `H` is hidden size, `r` is rank)
+- **Parameter Efficient**: Only `r×(H×2)` parameters per transformed layer (where `H` is hidden size, `r` is rank)
 - **Multiplicative**: Transformations scale proportionally with activation magnitude
+- **LoRA-Compatible**: Uses standard LoRA factorisation structure (BA) for easy adaptation of existing code
 
 ### When to Use Control Adapters
 
@@ -120,7 +121,7 @@ The current approach using symmetric matrices `Q diag(λ) Q^T` with log-paramete
 - Behavioural steering (tone, style, personality, prose)
 - Bidirectional learning (enhance/suppress behaviours using the same model)
 - "Unlearning" specific behaviours
-- Scenarios requiring precise control reversal
+- Scenarios requiring control reversal
 
 **Consider alternatives for:**
 
@@ -133,7 +134,7 @@ The current approach using symmetric matrices `Q diag(λ) Q^T` with log-paramete
 Control Adapters are conceptually similar to [Control Vectors](https://github.com/jukofyork/control-vectors), which also steer model behaviour by intervening in the residual stream. However:
 
 - **Control Vectors**: Compute steering directions analytically using eigenvector analysis of the symmetrised cross-covariance matrix. Applied via additive combination, where multiple vectors can interfere when used simultaneously.
-- **Control Adapters**: Learn steering transformations through gradient-based training. More forgiving for "fuzzy" criteria like writing style. The `Q` matrix learns a task-specific subspace while `S` parameters provide per-direction scaling effects.
+- **Control Adapters**: Learn steering transformations through gradient-based training. More forgiving for "fuzzy" criteria like writing style. The low-rank structure provides task-specific directional control with learned scaling.
 - **Complementary usage**: Control Vectors provide additive translation while Control Adapters provide multiplicative scaling along learned directions. Together they enable richer intervention patterns than either method alone.
 
 ## Mathematical Foundation
@@ -144,54 +145,54 @@ Control Adapters apply multiplicative transformations to the residual delta prod
 
 ```
 layer_delta = layer_output - input_hidden_states
-adapter_output = Q diag(λ) Q^T @ layer_delta
+adapter_output = B @ A @ dropout(layer_delta)
 final_output = layer_output + adapter_output
 ```
 
 Where:
 
-- **`Q ∈ ℝ^{H×r}`**: Semi-orthogonal matrix spanning a learned subspace  
-- **`λ ∈ ℝ^r`**: Per-direction eigenvalue offsets
+- **`A ∈ ℝ^{r×H}`**: Down-projection matrix (hidden_size → adapter_rank)
+- **`B ∈ ℝ^{H×r}`**: Up-projection matrix (adapter_rank → hidden_size)
+- **`W = BA ∈ ℝ^{H×H}`**: Composite low-rank transformation matrix
 - **`r`**: Adapter rank (typically 16-64)
 - **`H`**: Hidden dimension
 
-### Log-Parameterisation
+This structure is identical to standard LoRA, but applied multiplicatively to residual deltas rather than additively to weights.
 
-Eigenvalues are derived from learnable parameters `S`:
+### Neumann Series Inverse Approximation
+
+For bidirectional control, we need to approximate `(I + W)^{-1}` for negative examples. The Neumann series provides:
 
 ```
-λ = exp(S) - 1
+(I + W)^{-1} = I - W + W² - W³ + ...
 ```
 
-This parameterisation provides several key advantages:
+This series converges when the spectral norm `‖W‖₂ < 1`. Control Adapters use a **1st-order approximation**:
 
-- **Mathematical stability**: `1 + λ = exp(S) > 0` always, ensuring well-conditioned transformations
-- **Identity initialisation**: `S=0 → λ=0` → no change initially, allowing gradual learning
-- **Natural inverses**: Exact bidirectionality via `exp(-S) - 1` using the same learned parameters
-- **Smooth regularisation**: Symmetric behaviour in log-space for both forward and inverse directions
-- **Spectral control**: Interpretable eigenvalue-based scaling along learned directions
-- **Unbounded range**: Unlike constrained parameterisations, `S` can take any real value while keeping transformations stable
+- **Forward (Class `+1`)**: Apply `W` directly: `(I + W) × delta ≈ delta + W × delta`
+- **Inverse (Class `-1`)**: Apply `-W` for 1st-order inverse: `(I + W)^{-1} × delta ≈ delta - W × delta`
 
-### Bidirectional Control
+**Convergence and Accuracy:**
 
-The key innovation is principled inverse transformations:
+When `‖W‖₂ ≲ 0.25`, the 1st-order truncation error is `O(‖W‖₂²) ≤ 1-2%`. The training regularisation maintains this spectral norm bound to ensure:
 
-- **Forward (Class `+1`)**: `λ = exp(S) - 1`
-- **Inverse (Class `-1`)**: `λ' = exp(-S) - 1 = -λ/(1+λ)`
+- Convergence guarantee (`‖W‖₂ < 1`)
+- Acceptable approximation error (`‖W‖₂ < 0.25`)
 
-This provides mathematical guarantees:
+**Scalar Intuition:**
 
-- Class `-1` exactly undoes Class `+1` transformations when `Q^T Q = I`
-- Perfect bidirectional control using the same parameters
-- In practice, effects are approximate due to operating on residual deltas and semi-orthogonality
+For scalar `δ` with `|δ| < 1`:
+- True inverse: `1/(1 + δ)`
+- 1st order: `1 - δ` (error ≈ `δ²`)
+- Example with `δ = 0.1`: `1/1.1 ≈ 0.9091` vs `1 - 0.1 = 0.9000` (≈1% error)
 
-### Orthogonality Constraint
+### Norm Monitoring
 
-The method maintains `Q^T Q ≈ I_r` through regularisation, ensuring:
+Since computing `‖W‖₂` directly is expensive, we monitor the **Frobenius norm** `‖W‖_F` instead:
 
-- Stable matrix operations
-- Predictable eigenvalue behaviour
-- Numerical stability during training
+- For rank-`r` matrices: `‖W‖₂ ≤ ‖W‖_F ≤ √r · ‖W‖₂`
+- Target: `‖W‖_F < 0.25√r` ensures `‖W‖₂ ≲ 0.25` with balanced singular values
+- Regularisation maintains this bound via L2 weight decay on the composite matrix
 
 ## Configuration
 
@@ -211,8 +212,7 @@ lora_weight_dtype = "float32"     # Recommended for stability
 
 ```toml
 # Regularisation
-lora_weight_decay = 10.0          # L2 decay on S parameters (requires float32)
-control_adapter_gamma = 0.5       # Orthogonality step size (0, 0.5]
+lora_weight_decay = 10.0          # L2 decay on composite W = BA (requires float32)
 
 # Layer targeting
 layers_to_transform = "0:29"      # Transform layers 0-29 (inclusive)
@@ -222,8 +222,8 @@ layers_to_transform = "0:29"      # Transform layers 0-29 (inclusive)
 ### Important Notes
 
 - **Float32 required**: If using `lora_weight_decay > 0`, you *must* set `lora_weight_dtype = "float32"`
-- **Gamma bounds**: `control_adapter_gamma` must be in range `(0, 0.5]` for numerical stability
 - **Layer selection**: Can target specific layers; omit `layers_to_transform` to use all
+- **Weight decay range**: Typical values 1.0-20.0; higher values enforce stricter norm bounds
 
 ## Data and Classes
 
@@ -232,7 +232,7 @@ layers_to_transform = "0:29"      # Transform layers 0-29 (inclusive)
 Each example/document in your training data uses a control class:
 
 - **Class `+1`**: Apply forward transformation (enhance behaviour)
-- **Class `-1`**: Apply inverse transformation (suppress behaviour)  
+- **Class `-1`**: Apply inverse approximation (suppress behaviour)  
 - **Class `0`**: Randomised regulariser. During preprocessing, each example marked `0` is deterministically mapped to `+1` or `-1` (`≈ 50/50`). This injects controlled label noise to reduce overfitting and prevents the model from assuming controls are always active. There is no special "neutral" behaviour in training - class `0` becomes `±1` before training.
 
 ### Dataset Configuration
@@ -285,12 +285,14 @@ For each decoder layer with Control Adapters:
 
 1. **Compute residual delta**: `layer_delta = layer_output - input_hidden_states`
 2. **Apply dropout** (if configured) and cast to adapter dtype
-3. **Project to subspace**: `x_q = layer_delta @ Q`  
+3. **Apply control adapter**: `adapter_output = B(A(dropout(layer_delta)))`
 4. **Class-conditional transformation**:
-   - Class `+1`: `λ = exp(S) - 1`
-   - Class `-1`: `λ' = exp(-S) - 1`
-5. **Reconstruct**: `adapter_output = (x_q * λ) @ Q^T`
-6. **Add to residual stream**: `final_output = layer_output + adapter_output`
+   - **Class `+1`**: Add `adapter_output` to apply forward transformation `(I + W) × delta`
+   - **Class `-1`**: Apply Neumann series inverse approximation `(I + W)^{-1} × delta`:
+     - **1st-order** (default): Negate `adapter_output`, giving `(I - W) × delta`
+     - **Higher orders**: Compute `I - W + W² - W³ + ...` up to `INVERSE_APPROXIMATION_SERIES_ORDER`
+   - **Class `0`**: Zero out (padding tokens; labels = -100)
+5. **Add to residual stream**: `final_output = layer_output + adapter_output`
 
 Note on causal alignment:
 - The training pipeline uses causal language modelling. The control signal is shifted one token to align with next-token prediction (same mechanism as label shifting).
@@ -298,11 +300,10 @@ Note on causal alignment:
 
 ### Regularisation During Training
 
-Control Adapters employ three regularisation mechanisms:
+Control Adapters employ two regularisation mechanisms:
 
-1. **Orthogonality maintenance**: `Q ← Q - γ Q (Q^T Q - I)` with `γ = control_adapter_gamma` (mandatory analytical regularisation)
-2. **Eigenvalue shrinkage**: `S ← S - lr * lora_weight_decay * S` (optional analytical regularisation; prevents overfitting)
-3. **Class randomisation**: Examples marked `control_class = 0` are randomly assigned `±1` during preprocessing, injecting controlled label noise to improve generalisation and prevent overfitting to always-active controls
+1. **Weight decay**: L2 regularisation on composite matrix `W = BA` using `L = ½‖W‖_F²` (optional analytical regularisation; maintains spectral norm bounds for convergence)
+2. **Class randomisation**: Examples marked `control_class = 0` are randomly assigned `±1` during preprocessing, injecting controlled label noise to improve generalisation and prevent overfitting to always-active controls
 
 ## Analysis and Monitoring
 
@@ -310,8 +311,7 @@ Control Adapters employ three regularisation mechanisms:
 
 During training, monitor these metrics via TensorBoard:
 
-- **`train/norms_{avg,min,max}`**: Spectral norms (≈ `max |λ|`) per layer
-- **`train/orthogonality_{avg,min,max}`**: `‖Q^T Q - I‖_F²` constraint satisfaction
+- **`train/norms_{avg,min,max}`**: Frobenius norms `‖W‖_F` per layer
 - **`train/weight_decay_{avg,min,max}`**: Norm reduction from regularisation (if applied)
 
 ### Analysis Tool
@@ -322,16 +322,21 @@ Use the analysis tool for detailed post-training evaluation:
 python analyze_control_adapters.py --adapter /path/to/adapter [--no-gpu]
 ```
 
-This provides per-layer metrics including orthogonality errors, effective rank usage, and approximation quality.
+This provides per-layer metrics including spectral norms, Frobenius norms, effective rank, condition numbers, and convergence status.
 
 ### Interpreting Key Metrics
 
-| Metric | Good Values | What It Means |
-|--------|-------------|---------------|
-| Orthogonality error | < 1.0 (excellent < 0.5) | `Q` matrix maintains good subspace properties |
+| Metric | Target Values | What It Means |
+|--------|---------------|---------------|
+| Spectral norm (`‖W‖₂`) | < 0.25 (must be < 1) | Ensures convergence and low approximation error |
+| Frobenius norm (`‖W‖_F`) | < 0.25√r | Proxy for spectral norm (cheaper to compute during training) |
 | Effective rank | Close to adapter rank | Adapter is using its full capacity |
-| Approximation errors | < 5% (poor > 20%) | Orthogonality assumption holds well |
 | Condition number | < 100 (poor > 1000) | Numerically stable transformations |
+
+**Warning indicators:**
+- `‖W‖₂ ≥ 1`: Neumann series may diverge (critical!)
+- `‖W‖₂ ≥ 0.25`: Approximation error exceeds 1-2% target
+- Low effective rank: Potential rank collapse or underutilisation
 
 ## Conversion to LoRA
 
@@ -350,7 +355,7 @@ python control_adapter_to_lora.py \
   --base /path/to/base_model \
   --adapter /path/to/control_adapter \
   --output /path/to/lora_output \
-  [--inverse] [--model-specific-flags]
+  [--inverse] [--rank R] [--model-specific-flags]
 ```
 
 NOTE: Targets `mlp.down_proj` by default; use `--cohere` or `--mixtral N` to include additional modules.
@@ -358,19 +363,29 @@ NOTE: Targets `mlp.down_proj` by default; use `--cohere` or `--mixtral N` to inc
 **Key options:**
 
 - `--inverse`: Convert inverse branch (class `-1` behaviour) instead of forward branch (useful for testing!)
+- `--rank R`: Override output rank (default: use adapter rank)
 - `--cohere`: Also target `o_proj` layers (for `Cohere` models only)
 - `--mixtral N`: Target `experts.{0..N-1}.w2` (for `Mixtral` models only)
 
 ### Conversion Math
 
-The conversion uses an exact low-rank mapping to an additive LoRA:
+The conversion computes the effect on model weights and approximates via SVD:
 
-1. Compute eigenvalue offsets: `λ = exp(S) - 1` (or `λ' = exp(-S) - 1` for `--inverse`)
-2. Compute delta to base weight: `ΔW = (Q diag(λ) Q^T) @ W_base`
-3. Exact LoRA factorisation:
-   - `B = Q diag(λ)`  (shape `[H, r]`)
-   - `A = Q^T W_base` (shape `[r, N]`)
-   - Then `ΔW = B @ A` exactly, with rank `r` preserved (no SVD, no truncation).
+1. **Compute effect on weights**: 
+   - Forward: `delta = W @ weight` where `W = BA`
+   - Inverse: `delta = ((I + W)^{-1} - I) @ weight` (exact inverse)
+
+2. **SVD approximation**: `delta ≈ U @ diag(√S) @ V^T`
+
+3. **LoRA factorisation**:
+   - `A_lora = diag(√S) @ V^T` (shape `[rank, output_size]`)
+   - `B_lora = U @ diag(√S)` (shape `[hidden_size, rank]`)
+   - Result: `delta ≈ B_lora @ A_lora` with specified rank
+
+**Rank Selection:**
+- Default: Uses original adapter rank
+- Override with `--rank R` to reduce/increase rank
+- Tool reports variance explained by chosen rank
 
 ### Deployment
 
@@ -412,8 +427,8 @@ NOTE: Mixtral is not yet supported by `lora_to_gguf.py` - use [convert_lora_to_g
 ### Training
 
 - **Learning rate**: Start with `2e-4`, typical range is `1e-5` to `1e-3`
-- **Weight decay**: Use moderate values (`1.0`-`20.0`) when using `float32`
-- **Monitor orthogonality**: Keep orthogonality error well below `1.0` during training
+- **Weight decay**: Use moderate values (`1.0`-`20.0`) to maintain norm bounds
+- **Monitor norms**: Keep spectral norm well below `0.25` during training (ideally `0.15-0.20`)
 - **Check both directions**: Test that forward/inverse behaviours work as expected via the `--inverse` option (see above)
 
 ### Data Preparation
@@ -425,25 +440,25 @@ NOTE: Mixtral is not yet supported by `lora_to_gguf.py` - use [convert_lora_to_g
 
 ### Debugging Common Issues
 
-- **Persistent High orthogonality error (>1.0)**: Reduce learning rate or increase `control_adapter_gamma`
-- **Sudden norm spikes**: Check for gradient explosion, reduce learning rate, increase `lora_weight_decay`
+- **High spectral norms (>0.25)**: Increase `lora_weight_decay` or reduce learning rate
+- **Norm spikes**: Check for gradient explosion, reduce learning rate, increase `lora_weight_decay`
 - **Poor effective rank (<50% of adapter rank)**: Try more training data, more diverse training data, or reduce `lora_rank`
-- **High approximation errors (>20%)**: Reduce learning rate and/or increase regularisation parameters
+- **Convergence warnings (‖W‖₂ ≥ 1)**: Critical issue - increase weight decay significantly or reduce learning rate
 
 ## Files and Tools
 
 ### Core Implementation
 
 - `training/control_adapters.py`: Main implementation and training logic
-- `training/regularizer.py`: Orthogonality and weight decay regularisation
+- `training/regularizer.py`: Weight decay regularisation for composite matrices
 
 ### Analysis Tools
 
-- `analyze_control_adapters.py`: Comprehensive adapter analysis with per-layer metrics
+- `analyze_control_adapters.py`: Comprehensive adapter analysis with per-layer metrics and convergence status
 
 ### Conversion Tools
 
-- `control_adapter_to_lora.py`: Convert to standard LoRA format for deployment
+- `control_adapter_to_lora.py`: Convert to standard LoRA format via SVD approximation
 - `merge_lora.py`: Standard LoRA merging tool (use after conversion)
 - `lora_to_gguf.py`: Export a LoRA adapter to GGUF for [llama.cpp](https://github.com/ggml-org/llama.cpp)
 

--- a/examples/config_control_adapter.toml
+++ b/examples/config_control_adapter.toml
@@ -28,16 +28,10 @@ lora_dropout = 0.0                 # Dropout on residual delta (default: 0.0)
 # NOTE: To use lora_weight_decay, this must be left as float32.
 lora_weight_dtype = "float32"      # Required for numerical stability (default: "float32")
 
-# L2 weight decay regularization for Control Adapters: L2 regularization on log-eigenvalue vector S using L = ½||S||²
+# L2 weight decay regularization for composite matrix W = BA
 # NOTE: Requires lora_weight_dtype = "float32" when > 0 for numerical stability
-# NOTE: When using Control Adapters, increase lora_weight_decay to 100-500+ for mathematical stability
-lora_weight_decay = 100.0          # L2 regularization on log-eigenvalues S (higher for Control Adapters) (default: 0.0)
-
-# (** Control Adapters only **): Orthogonality regularization step size for Q
-# Controls Newton-style step: Q ← Q − γ·Q·(Q^T Q − I) to maintain Q^T Q ≈ I
-# NOTE: Allowed range (0, 0.5], as values > 0.5 may cause divergence
-# NOTE: Recommend lora_weight_dtype = "float32" for numerical stability, but should still work with bfloat16.
-control_adapter_gamma = 0.5        # Range (0, 0.5], controls Q^T Q ≈ I maintenance (default: 0.5 = full Newton step)
+# NOTE: For Control Adapters, use moderate values (1.0-20.0) to maintain spectral norm bounds
+lora_weight_decay = 10.0           # L2 regularization on composite W = BA (default: 0.0)
 
 # =====================
 # OPTIMIZER CONFIGURATION
@@ -185,7 +179,7 @@ max_tokens = 500000
 # - max_tokens: Maximum number of tokens to keep from this dataset after shuffling (default: unlimited)
 # - control_class: Must be -1, 0, or 1 (only used with Control Adapters)
 #   * control_class = 1: Apply forward transformation (enhance behavior)
-#   * control_class = -1: Apply inverse transformation (suppress behavior)
+#   * control_class = -1: Apply inverse approximation (suppress behavior)
 #   * control_class = 0: Randomized regularizer (deterministically mapped to ±1 during preprocessing)
 
 # Notes:

--- a/training/control_adapters.py
+++ b/training/control_adapters.py
@@ -19,6 +19,8 @@ import re
 import safetensors.torch
 import torch
 
+from constants import NEUMANN_SERIES_ORDER
+
 def apply_control_adapters(model, layers_to_transform, adapter_rank, adapter_dropout, adapter_dtype=torch.float32):
     """
     Inject Control Adapter parameters into decoder layers and patch their forward method.
@@ -47,11 +49,6 @@ def apply_control_adapters(model, layers_to_transform, adapter_rank, adapter_dro
         - Sets original_name for saving compatibility
         - Sets requires_grad True for control_A/control_B and False for other parameters
     """
-
-    # For the inverse approximation (I + W)^{-1}, when ‖W‖₂ ≲ 0.2–0.3, the 1st-order truncation
-    # error O(‖W‖₂²) ≤ 1–2%. Going to order 2 halves the error (O(‖W‖₂³)) but doubles the matmul cost.
-    # Order 3+ yields less than 0.1% improvement in the intended ‖W‖₂ norm range.
-    INVERSE_APPROXIMATION_SERIES_ORDER = 1
 
     # The Neumann series for matrix inverse: (I + W)^{-1} = I - W + W^2 - W^3 + ...
     # converges when ρ(W) < 1, where ρ(W) is the spectral radius (max |eigenvalue|).
@@ -117,7 +114,7 @@ def apply_control_adapters(model, layers_to_transform, adapter_rank, adapter_dro
             # For positive samples: Add adapter_output as normal
             # For negative samples: Apply kth-order Neumann series approximation of (I + W)^{-1}
             negate_mask = (shift_control_classes == -1).unsqueeze(-1)  # broadcast to (batch_size, seq_len, 1)
-            if INVERSE_APPROXIMATION_SERIES_ORDER == 1:
+            if NEUMANN_SERIES_ORDER == 1:
                 # Simple 1st-order case: (I + W)^{-1} ≈ I - W, so just negate the output
                 adapter_output = torch.where(negate_mask, -adapter_output, adapter_output)
             else:
@@ -125,7 +122,7 @@ def apply_control_adapters(model, layers_to_transform, adapter_rank, adapter_dro
                 neumann_sum = adapter_output  # Start with W^1 term
                 current_power = adapter_output
 
-                for k in range(1, INVERSE_APPROXIMATION_SERIES_ORDER):
+                for k in range(1, NEUMANN_SERIES_ORDER):
                     # Compute next power: W^(k+1) (no dropout on higher order terms)
                     current_power = module.control_B(module.control_A(current_power))
 

--- a/training/control_adapters.py
+++ b/training/control_adapters.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from tqdm import tqdm
 from typing import Dict, List, Tuple
 import json
+import math
 import re
 import safetensors.torch
 import torch
@@ -25,26 +26,55 @@ def apply_control_adapters(model, layers_to_transform, adapter_rank, adapter_dro
     Parameters:
         model               : Pipeline model containing DecoderLayerPipe modules (with 'orig' submodule).
         layers_to_transform : list[int] | None, layer indices to transform; None transforms all decoder layers.
-        adapter_rank        : int, the rank (r) for the adapter subspace (shape: hidden_size x r).
+        adapter_rank        : int, the rank (r) for the adapter subspace.
         adapter_dropout     : float in [0, 1], dropout probability applied to residual delta before projection.
         adapter_dtype       : torch.dtype for the adapter parameters (e.g., torch.float32).
 
     Behavior:
         - For each selected decoder layer:
           * Adds control_dropout module (Dropout or Identity)
-          * Creates trainable parameters:
-              - control_Q: [hidden_size, r], orthogonally initialized
-              - control_S: [r], zeros initialized (log-parameterization of λ: 1 + λ = exp(S))
-          * Casts control_Q and control_S to adapter_dtype
+          * Creates trainable Linear layers:
+              - control_A: Linear(hidden_size, adapter_rank, bias=False)
+              - control_B: Linear(adapter_rank, hidden_size, bias=False)
+          * Casts control_A and control_B weights to adapter_dtype
           * Patches layer.forward with a wrapper that:
               - Computes residual delta
-              - Projects into Q-subspace
-              - Applies class-conditional transform using expm1(S) and its inverse
+              - Applies dropout -> A -> B
+              - For positive samples (class 1): adds adapter output
+              - For negative samples (class -1): applies 1st-order Neumann series (negates adapter output)
               - Masks class 0 positions to zero contribution
               - Adds adapter contribution back to residual stream
         - Sets original_name for saving compatibility
-        - Sets requires_grad True for control_Q/control_S and False for other parameters on the layer
+        - Sets requires_grad True for control_A/control_B and False for other parameters
     """
+
+    # For the inverse approximation (I + W)^{-1}, when ‖W‖₂ ≲ 0.2–0.3, the 1st-order truncation
+    # error O(‖W‖₂²) ≤ 1–2%. Going to order 2 halves the error (O(‖W‖₂³)) but doubles the matmul cost.
+    # Order 3+ yields less than 0.1% improvement in the intended ‖W‖₂ norm range.
+    INVERSE_APPROXIMATION_SERIES_ORDER = 1
+
+    # The Neumann series for matrix inverse: (I + W)^{-1} = I - W + W^2 - W^3 + ...
+    # converges when ρ(W) < 1, where ρ(W) is the spectral radius (max |eigenvalue|).
+    # NOTE: Requiring the spectral norm ‖W‖₂ < 1 is a sufficient condition because ρ(W) ≤ ‖W‖₂.
+    #
+    # Scalar intuition: For 1/(1 + δ) where |δ| < 1:
+    #   True value: 1/(1 + δ)
+    #   1st order:  1 - δ                    (error ≈ δ^2)
+    #   2nd order:  1 - δ + δ^2              (error ≈ δ^3)
+    #
+    # Example with δ = 0.1:
+    #   True:     1/1.1 ≈ 0.9091
+    #   1st:      1 - 0.1 = 0.9000          (error ≈ 1.0%)
+    #   2nd:      1 - 0.1 + 0.01 = 0.9100   (error ≈ 0.1%)
+    #
+    # For Control Adapters (W = B @ A):
+    # - Computing ‖W‖₂ is expensive, so we monitor ‖W‖_F instead (via `norm_avg` and `norm_max` metrics)
+    # - For rank-r matrices: ‖W‖₂ ≤ ‖W‖_F ≤ √r · ‖W‖₂ (depending on singular value distribution)
+    # - Keeping ‖W‖_F ≲ 0.25 √r ensures:
+    #   • With balanced singular values: ‖W‖₂ ≈ 0.25
+    #   • Worst-case: ‖W‖₂ ≤ 0.25 √r
+    # - Using `_apply_lora_weight_decay_local()` maintains this by properly scaling all
+    #   singular values of the W = BA composite, unlike naive weight decay on A and B separately.
 
     def patch_decoder_layer_control_adapter(module):
 
@@ -74,38 +104,38 @@ def apply_control_adapters(model, layers_to_transform, adapter_rank, adapter_dro
             )[0]
             torch_result_dtype = layer_output.dtype
 
-            # Compute residual delta, apply optional dropout, then cast to adapter dtype
-            layer_delta = layer_output - input_hidden_states
-            x = module.control_dropout(layer_delta).to(module.control_Q.dtype)
+            # Calculate the delta and cast to the adapter's dtype
+            layer_delta = (layer_output - input_hidden_states).to(module.control_A.weight.dtype)
 
-            # Project to adapter subspace via Q (semi-orthogonal columns: Q^T Q ≈ I_r)
-            x_q = x @ module.control_Q  # [batch_size, seq_len, adapter_rank]
+            # Apply Control Adapter: dropout -> A -> B
+            adapter_output = module.control_B(module.control_A(module.control_dropout(layer_delta)))
 
-            # Per-rank eigenvalue offsets in the Q-subspace using a log-parameterization:
-            # λ = exp(S) - 1, so 1 + λ = exp(S) > 0 and the forward operator is I + diag(λ)
-            lambda_pos_coeff = torch.expm1(module.control_S)  # [adapter_rank]
-
-            # Exact inverse for the -1 branch (exact if Q is orthonormal; otherwise approximate):
-            # (I + Q diag(λ) Q^T)^{-1} - I = -Q diag(λ/(1+λ)) Q^T
-            # Identity: λ' = -λ/(1+λ) = exp(-S) - 1
-            lambda_neg_coeff = torch.expm1(-module.control_S)  # [adapter_rank]
-
-            # +1 class delta: Q diag(λ) Q^T x
-            out_pos = ((x_q * lambda_pos_coeff) @ module.control_Q.T)  # [batch_size, seq_len, hidden_size]
-
-            # -1 class delta (exact inverse): Q diag(λ') Q^T x
-            out_neg = ((x_q * lambda_neg_coeff) @ module.control_Q.T)  # [batch_size, seq_len, hidden_size]
-
-            # Select +1 branch where class==1; otherwise use inverse branch (class -1)
-            class1_mask = (shift_control_classes == 1).unsqueeze(-1)  # broadcast to [batch_size, seq_len, 1]
-            adapter_output = torch.where(class1_mask, out_pos, out_neg)
-
-            # 0 class: zero-out (no loss; labels = -100)
-            class0_mask = (shift_control_classes == 0).unsqueeze(-1)  # broadcast to [batch_size, seq_len, 1]
+            # Zero out any with class zero, as these won't have any loss calculated due to having label = -100
+            class0_mask = (shift_control_classes == 0).unsqueeze(-1)  # broadcast to (batch_size, seq_len, 1)
             adapter_output = torch.where(class0_mask, torch.zeros_like(adapter_output), adapter_output)
 
+            # For positive samples: Add adapter_output as normal
+            # For negative samples: Apply kth-order Neumann series approximation of (I + W)^{-1}
+            negate_mask = (shift_control_classes == -1).unsqueeze(-1)  # broadcast to (batch_size, seq_len, 1)
+            if INVERSE_APPROXIMATION_SERIES_ORDER == 1:
+                # Simple 1st-order case: (I + W)^{-1} ≈ I - W, so just negate the output
+                adapter_output = torch.where(negate_mask, -adapter_output, adapter_output)
+            else:
+                # Higher order: compute Neumann series for negative samples
+                neumann_sum = adapter_output  # Start with W^1 term
+                current_power = adapter_output
+
+                for k in range(1, INVERSE_APPROXIMATION_SERIES_ORDER):
+                    # Compute next power: W^(k+1) (no dropout on higher order terms)
+                    current_power = module.control_B(module.control_A(current_power))
+
+                    # Add (-1)^k * W^(k+1) to the series
+                    neumann_sum = neumann_sum + ((-1.0) ** k) * current_power
+
+                adapter_output = torch.where(negate_mask, -neumann_sum, adapter_output)
+
             # Cast adapter contribution back to original dtype and add to the residual stream
-            result = layer_output + adapter_output.to(torch_result_dtype)  # [batch_size, seq_len, hidden_size]
+            result = layer_output + adapter_output.to(torch_result_dtype)
 
             return (result, attention_mask, cos, sin, cache_position, control_classes, labels)
 
@@ -124,21 +154,21 @@ def apply_control_adapters(model, layers_to_transform, adapter_rank, adapter_dro
                 module.control_dropout = torch.nn.Dropout(p=adapter_dropout) if adapter_dropout > 0 else torch.nn.Identity()
                 module.control_dropout = module.control_dropout.to(device)
 
-                # Create Control Adapter parameters
-                module.control_Q = torch.nn.Parameter(torch.empty(hidden_size, adapter_rank, device=device))
-                module.control_S = torch.nn.Parameter(torch.empty(adapter_rank, device=device))
+                # Create Control Adapter layers (following PEFT pattern)
+                module.control_A = torch.nn.Linear(hidden_size, adapter_rank, bias=False).to(device)
+                module.control_B = torch.nn.Linear(adapter_rank, hidden_size, bias=False).to(device)
 
                 # Add original_name for saving compatibility
-                module.control_Q.original_name = f"base_model.model.model.layers.{layer_idx}.control_Q"
-                module.control_S.original_name = f"base_model.model.model.layers.{layer_idx}.control_S"
+                module.control_A.weight.original_name = f"base_model.model.model.layers.{layer_idx}.control_A.weight"
+                module.control_B.weight.original_name = f"base_model.model.model.layers.{layer_idx}.control_B.weight"
 
                 # Initialize
-                torch.nn.init.orthogonal_(module.control_Q)
-                torch.nn.init.zeros_(module.control_S)
+                torch.nn.init.kaiming_uniform_(module.control_A.weight, a=math.sqrt(5))
+                torch.nn.init.zeros_(module.control_B.weight)
 
                 # Cast to the desired dtype
-                module.control_Q.data = module.control_Q.data.to(adapter_dtype)
-                module.control_S.data = module.control_S.data.to(adapter_dtype)
+                module.control_A.weight.data = module.control_A.weight.data.to(adapter_dtype)
+                module.control_B.weight.data = module.control_B.weight.data.to(adapter_dtype)
 
                 # Replace forward with Control Adapter version
                 module.forward = patch_decoder_layer_control_adapter(module)
@@ -150,37 +180,10 @@ def apply_control_adapters(model, layers_to_transform, adapter_rank, adapter_dro
 
     # Disable gradients for all base model parameters, enable only for Control Adapters
     for name, p in model.named_parameters():
-        if 'control_Q' in name or 'control_S' in name:
+        if 'control_A' in name or 'control_B' in name:
             p.requires_grad = True
         else:
             p.requires_grad = False
-
-def apply_control_adapter_transform(Q, S, device=None, inverse: bool=False):
-    """Compute Control Adapter delta: Q diag(λ) Q^T (forward) or exact inverse.
-
-    Definitions:
-        - Forward delta: λ = exp(S) - 1,      result = Q diag(λ) Q^T
-        - Exact inverse: λ' = exp(-S) - 1,    result = Q diag(λ') Q^T
-          (equivalently (I + Q diag(λ) Q^T)^{-1} - I = -Q diag(λ/(1+λ)) Q^T)
-
-    Args:
-        Q (Tensor): [hidden_size, r], semi-orthogonal columns (Q^T Q ≈ I_r).
-        S (Tensor): [r], log-parameterization of eigenvalue offsets.
-        device (str|torch.device|None): device to run on; defaults to 'cuda' if available else 'cpu'.
-        inverse (bool): when True, compute exact inverse delta; otherwise forward delta.
-
-    Returns:
-        Tensor: [hidden_size, hidden_size] delta on the specified device (float32).
-    """
-    if device is None:
-        device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-
-    Q_gpu = Q.to(device=device, dtype=torch.float32)
-    S_gpu = S.to(device=device, dtype=torch.float32)
-
-    coeff = torch.expm1(-S_gpu) if inverse else torch.expm1(S_gpu)
-    result = (Q_gpu * coeff.unsqueeze(0)) @ Q_gpu.T
-    return result
 
 def load_control_adapter_weights(adapter_path: Path) -> Tuple[List[Tuple[str, torch.Tensor]], Dict[str, torch.Tensor]]:
     """Load control adapter weights and return (sorted key-value pairs, full state dict)."""
@@ -201,11 +204,11 @@ def load_control_adapter_weights(adapter_path: Path) -> Tuple[List[Tuple[str, to
     def _extract_layer_num(item):
         """Extract layer number and parameter type from control adapter key for sorting."""
         key, _ = item
-        match = re.search(r'layers\.(\d+)\.control_(Q|S)', key)
+        match = re.search(r'layers\.(\d+)\.control_(A|B)', key)
         if match:
             layer_num = int(match.group(1))
             param_type = match.group(2)
-            return (layer_num, 0 if param_type == 'Q' else 1)
+            return (layer_num, 0 if param_type == 'A' else 1)
         return (float('inf'), 2)
 
     state_dict, _ = _find_and_load_adapter_weights(adapter_path)
@@ -214,11 +217,11 @@ def load_control_adapter_weights(adapter_path: Path) -> Tuple[List[Tuple[str, to
     return control_keys, state_dict
 
 def parse_control_adapter_keys(state_dict: Dict[str, torch.Tensor]) -> Dict[int, Dict[str, torch.Tensor]]:
-    """Parse control adapter state dict into layer -> {Q, S} mapping."""
+    """Parse control adapter state dict into layer -> {A, B} mapping."""
     control_adapters: Dict[int, Dict[str, torch.Tensor]] = {}
 
     for key, tensor in state_dict.items():
-        match = re.search(r'layers\.(\d+)\.control_(Q|S)', key)
+        match = re.search(r'layers\.(\d+)\.control_(A|B)', key)
         if match:
             layer_idx = int(match.group(1))
             param_type = match.group(2)

--- a/training/engine.py
+++ b/training/engine.py
@@ -237,8 +237,19 @@ class Engine:
         Returns:
             torch.optim.Optimizer: The initialized optimizer instance.
         """
+        params = list(model_parameters)
+
+        # Handle pipeline stages with no trainable layers (e.g., when layers_to_transform
+        # targets specific layers that all landed on other stages with uniform partitioning).
+        # This creates a dummy parameter to satisfy the optimizer initialization without
+        # affecting training, allowing the stage to participate in forward/backward only.
+        if len(params) == 0:
+            device = torch.device(f"cuda:{torch.cuda.current_device()}" if torch.cuda.is_available() else "cpu")
+            dummy = torch.nn.Parameter(torch.zeros(1, device=device), requires_grad=True)
+            params = [dummy]
+
         optimizer_kwargs = {
-            "params": model_parameters,
+            "params": params,
             "lr": config['lr'],
             "betas": (config.get('beta1', DEFAULT_BETA1), config.get('beta2', DEFAULT_BETA2)),
             "eps": config.get('eps', DEFAULT_EPS)

--- a/training/engine.py
+++ b/training/engine.py
@@ -82,6 +82,16 @@ class Engine:
 
         parameters_to_train = [p for p in pipeline_model.parameters() if p.requires_grad]
 
+        # Handle pipeline stages with no trainable layers (e.g., when layers_to_transform
+        # targets specific layers that all landed on other stages with uniform partitioning).
+        # Register a dummy parameter directly on the model so it appears in model.parameters()
+        # for DeepSpeed's gradient clipping and optimizer step.
+        if len(parameters_to_train) == 0:
+            device = torch.device(f"cuda:{torch.cuda.current_device()}" if torch.cuda.is_available() else "cpu")
+            dummy = torch.nn.Parameter(torch.zeros(1, device=device), requires_grad=True)
+            pipeline_model.register_parameter('ds_dummy_param', dummy)
+            parameters_to_train = [dummy]
+
         # Initialize DeepSpeed engine
         assert pipeline_model is not None, "deepspeed.initialize requires a model"
 
@@ -237,19 +247,8 @@ class Engine:
         Returns:
             torch.optim.Optimizer: The initialized optimizer instance.
         """
-        params = list(model_parameters)
-
-        # Handle pipeline stages with no trainable layers (e.g., when layers_to_transform
-        # targets specific layers that all landed on other stages with uniform partitioning).
-        # This creates a dummy parameter to satisfy the optimizer initialization without
-        # affecting training, allowing the stage to participate in forward/backward only.
-        if len(params) == 0:
-            device = torch.device(f"cuda:{torch.cuda.current_device()}" if torch.cuda.is_available() else "cpu")
-            dummy = torch.nn.Parameter(torch.zeros(1, device=device), requires_grad=True)
-            params = [dummy]
-
         optimizer_kwargs = {
-            "params": params,
+            "params": model_parameters,
             "lr": config['lr'],
             "betas": (config.get('beta1', DEFAULT_BETA1), config.get('beta2', DEFAULT_BETA2)),
             "eps": config.get('eps', DEFAULT_EPS)

--- a/training/model_factory.py
+++ b/training/model_factory.py
@@ -335,7 +335,7 @@ def convert_ds_checkpoint_to_lora(ds_checkpoint_dir, config_path, lora_output_di
     Filters out BitsAndBytes 4-bit buffers (absmax/quant_map/quant_state, etc.) and base model weights,
     keeping only adapter tensors:
       - LoRA: *.lora_A.weight / *.lora_B.weight (and optional modules_to_save.*)
-      - Control Adapters: control_Q / control_S
+      - Control Adapters: control_A.weight / control_B.weight
 
     Saved keys are normalized to HF/PEFT-compatible names:
       - Strips leading 'orig.' indirection introduced by pipeline wrappers
@@ -354,12 +354,10 @@ def convert_ds_checkpoint_to_lora(ds_checkpoint_dir, config_path, lora_output_di
 
     def _wants_key(name: str) -> bool:
         # Control adapters
-        if 'control_Q' in name or 'control_S' in name:
+        if 'control_A' in name or 'control_B' in name:
             return True
         # LoRA
-        if '.lora_A.' in name or name.endswith('.lora_A.weight'):
-            return True
-        if '.lora_B.' in name or name.endswith('.lora_B.weight'):
+        if 'lora_A' in name or 'lora_B' in name:
             return True
         # Optional PEFT "modules_to_save" items
         if '.modules_to_save.' in name:

--- a/training/regularizer.py
+++ b/training/regularizer.py
@@ -1,8 +1,6 @@
 from deepspeed import comm as dist
 import torch
 
-from constants import DEFAULT_CONTROL_ADAPTER_GAMMA
-
 class Regularizer:
     """
     Handles regularization for LoRA and Control Adapter parameters.
@@ -14,7 +12,7 @@ class Regularizer:
 
     Usage:
     - Call apply_regularization(model, config, lr) once per training step
-    - Path selection is based on config['use_control_adapters']
+    - Applies L2 weight decay to composite W = B @ A matrices
     - Returns a dict of aggregated metrics (avg/min/max) per key
     """
 
@@ -25,60 +23,33 @@ class Regularizer:
         self.pipeline_engine = pipeline_engine
 
     def apply_regularization(self, model, config, lr):
-        """Apply regularization to LoRA or Control Adapter parameters and return aggregated statistics.
+        """Apply L2 regularization to LoRA or Control Adapter composite matrices and return aggregated statistics.
 
         Behavior:
-            - If config['use_control_adapters'] is True, applies control adapter regularization
-              (orthogonality maintenance on Q and L2 shrinkage on S in log-space).
-            - Otherwise, applies LoRA regularization (L2 on composite W = B·A).
-            - Local stats are computed and then aggregated across pipeline stages.
+            - Searches for both lora_A/lora_B and control_A/control_B parameter pairs
+            - Applies L2 weight decay to composite W = B @ A using L = ½||W||_F²
+            - Local stats are computed and then aggregated across pipeline stages
 
         Returns:
             dict[str, float]: Global summary metrics containing avg/min/max for each reported key.
         """
-        use_control_adapters = config.get('use_control_adapters', False)
         lora_weight_decay = config.get('lora_weight_decay', 0.0)
+        assert lora_weight_decay >= 0, f"lora_weight_decay ({lora_weight_decay}) must be >= 0"
 
-        if use_control_adapters:
-            gamma = config.get('control_adapter_gamma', DEFAULT_CONTROL_ADAPTER_GAMMA)
-            local_stats = self._apply_control_adapter_regularization_local(
-                model=model,
-                lr=lr,
-                gamma=gamma,
-                lora_weight_decay=lora_weight_decay,
-            )
-        else:
-            local_stats = self._apply_lora_regularization_local(
-                model=model,
-                lr=lr,
-                lora_weight_decay=lora_weight_decay,
-            )
-
-        return self._aggregate_statistics(local_stats)
-
-    def _apply_lora_regularization_local(self, model, lr, lora_weight_decay):
-        """Apply L2 regularization to the composite matrix W = B·A using L = ½||W||_F².
-
-        Returns:
-            dict with:
-              - 'norms'         : tensor of Frobenius norms (||W||_F) per pair of LoRA parameters
-              - 'weight_decay'  : tensor of Frobenius norm reductions due to the regularization (if applied)
-
-        Notes:
-            - Weight decay gradients are computed analytically and applied in-place to A and B.
-            - Requires A and B parameters to be float32 for numerical stability when lora_weight_decay > 0.
-            - Empty tensor(s) returned if no applicable parameters on this stage.
-        """
         norms = []
         weight_decay = []
 
-        assert lora_weight_decay >= 0, f"lora_weight_decay ({lora_weight_decay}) must be >= 0"
-
         for name, param in model.named_parameters():
-            if 'lora_A' in name:
+            if 'lora_A' in name or 'control_A' in name:
                 A = param
-                B_name = name.replace('lora_A', 'lora_B')
 
+                # Determine corresponding B name
+                if 'lora_A' in name:
+                    B_name = name.replace('lora_A', 'lora_B')
+                else:  # control_A
+                    B_name = name.replace('control_A', 'control_B')
+
+                # Find B parameter
                 try:
                     B = next(p for n, p in model.named_parameters() if n == B_name)
                 except StopIteration:
@@ -88,11 +59,11 @@ class Regularizer:
                     W = B @ A
                     W_norm = W.norm().item()
 
-                # L2-norm regularisation of the composite matrix using L = ½||W||_F²:
+                # L2-norm regularization of the composite matrix using L = ½||W||_F²:
                 if lora_weight_decay > 0:
                     # The very tiny values end up cancelling out to zero for float16/bfloat16 and decays all stay zero...
-                    assert A.dtype == torch.float32, f"LoRA A ({A.dtype}) must be float32"
-                    assert B.dtype == torch.float32, f"LoRA B ({B.dtype}) must be float32"
+                    assert A.dtype == torch.float32, f"Adapter A ({A.dtype}) must be float32"
+                    assert B.dtype == torch.float32, f"Adapter B ({B.dtype}) must be float32"
 
                     # Save the initial norm so we can calculate the weight decay after the (optional) updates
                     W_norm_initial = W_norm
@@ -124,155 +95,18 @@ class Regularizer:
         else:
             norms_tensor = torch.empty(0, dtype=torch.float32, device=self.pipeline_engine.device)
 
-        # Only return weight decay if regularization was applied
+        # Build local stats dict
+        local_stats = {'norms': norms_tensor}
+
+        # Only include weight decay if regularization was applied
         if lora_weight_decay > 0:
-            # Convert to tensors, handling empty case
             if len(weight_decay) > 0:
                 weight_decay_tensor = torch.tensor(weight_decay, dtype=torch.float32, device=self.pipeline_engine.device)
             else:
                 weight_decay_tensor = torch.empty(0, dtype=torch.float32, device=self.pipeline_engine.device)
-            return {
-                'norms': norms_tensor,
-                'weight_decay': weight_decay_tensor
-            }
-        else:
-            return {
-                'norms': norms_tensor
-            }
+            local_stats['weight_decay'] = weight_decay_tensor
 
-    def _apply_control_adapter_regularization_local(self, model, lr, gamma, lora_weight_decay):
-        """Apply orthogonality regularization to Q and weight decay to S.
-
-        - Q orthogonality : Newton step (full or partial) to maintain Q^T Q ≈ I.
-        - S shrinkage     : L2 weight decay on the log-eigenvalues S where 1 + λ = exp(S).
-
-        Math:
-          - Q orthogonalization:
-            F(Q) = ||Q^T Q − I||_F², grad F = 4 Q (Q^T Q − I).
-            A Newton step for F(Q) = 0 yields Q ← Q − (1/2) Q (Q^T Q − I).
-            We use Q ← Q − γ Q (Q^T Q − I), with γ ∈ (0, 0.5] for stability.
-          - S penalty: L_S = ½||S||² ⇒ ∂L_S/∂S = S.
-            With α = lr * lora_weight_decay, the update is S ← S − αS = (1 − α)S.
-            Since 1 + λ = exp(S), this implies multiplicative shrinkage:
-              1 + λ ← exp((1 − α)S) = (1 + λ)^{1−α}
-            So λ is symmetrically pulled toward 0 in log-space.
-          - Spectral norm tracking:
-            For W = Q diag(λ) Q^T, if Q^T Q = I then eig(W) = {λ_i} and ||W||₂ = max_i |λ_i|.
-            With semi-orthogonality (Q^T Q ≈ I), this remains a good approximation.
-
-        Returns:
-            dict with:
-              - 'norms'         : tensor of spectral norms (||W||₂ ≈ max|λ|) per layer
-              - 'orthogonality' : tensor of orthogonality residuals (||Q^T Q − I||_F²)
-              - 'weight_decay'  : tensor of spectral norm reductions due to S shrinkage (if applied)
-
-         Notes:
-             - Regularization gradients are computed analytically and applied in-place to Q and S.
-             - Recommend Q parameters to be float32 for numerical stability, but should still work with bfloat16.
-             - Requires S parameters to be float32 for numerical stability when lora_weight_decay > 0.
-             - Empty tensor(s) returned if no applicable parameters on this stage.
-        """
-        norms = []
-        orthogonality = []
-        weight_decay = []
-
-        assert gamma > 0, f"control_adapter_gamma ({gamma}) must be > 0 to maintain semi-orthogonality"
-        assert gamma <= 0.5, f"control_adapter_gamma ({gamma}) must be <= 0.5 to avoid overshooting"
-
-        assert lora_weight_decay >= 0, f"lora_weight_decay ({lora_weight_decay}) must be >= 0"
-
-        identity_matrix = None
-
-        for name, param in model.named_parameters():
-            if 'control_Q' in name:
-                Q = param
-
-                with torch.no_grad():
-                    # Reuse the same identity matrix for orthogonality regularization (all Q have same rank)
-                    if identity_matrix is None:
-                        identity_matrix = torch.eye(Q.size(1), device=Q.device, dtype=torch.float32)
-
-                    # Compute Newton step: γ Q (Q^T Q − I) in fp32 for stability
-                    Q_f32 = Q.float()
-                    QTQ_minus_I = Q_f32.t() @ Q_f32 - identity_matrix
-                    newton_step = (Q_f32 @ QTQ_minus_I).mul_(gamma)
-
-                    # Modify the tensor in place
-                    Q.sub_(newton_step.to(Q.dtype))
-
-                    # Compute orthogonality error after the update (in fp32)
-                    Q_f32 = Q.float()
-                    QTQ_minus_I = Q_f32.t() @ Q_f32 - identity_matrix
-                    orthogonality_error = (torch.norm(QTQ_minus_I, 'fro') ** 2).item()
-
-                # Save orthogonality error
-                orthogonality.append(orthogonality_error)
-
-            if 'control_S' in name:
-                S = param
-
-                with torch.no_grad():
-                    # Convert from log-parameterization: λ = exp(S) - 1, so 1 + λ = exp(S)
-                    lambda_vec = torch.expm1(S)
-
-                    # Calculate the spectral norm of W: ||W||₂ = max|λᵢ|
-                    W_norm = torch.max(torch.abs(lambda_vec)).item()
-
-                # L2-norm regularization of the log-eigenvalue vector S = log(λ + 1)
-                if lora_weight_decay > 0:
-                    # The very tiny values end up cancelling out to zero for float16/bfloat16 and decays all stay zero...
-                    assert S.dtype == torch.float32, f"Control Adapter S ({S.dtype}) must be float32"
-
-                    # Save the initial norm so we can calculate the weight decay after the (optional) updates
-                    W_norm_initial = W_norm
-
-                    with torch.no_grad():
-                        # L2 regularization of S: L = ½||S||²
-                        # ∂L/∂S = S
-                        grad_S = S
-
-                        # Modify the tensor in place
-                        S.sub_(lr * lora_weight_decay * grad_S)
-
-                        # Recompute lambda_vec and its norm using updated S
-                        lambda_vec = torch.expm1(S)
-                        W_norm = torch.max(torch.abs(lambda_vec)).item()
-
-                    # Save weight decay
-                    weight_decay.append(W_norm_initial - W_norm)
-
-                # Save the norms after the (optional) weight-decay update
-                norms.append(W_norm)
-
-        # Convert to tensors, handling empty case
-        if len(orthogonality) > 0:
-            orthogonality_tensor = torch.tensor(orthogonality, dtype=torch.float32, device=self.pipeline_engine.device)
-        else:
-            orthogonality_tensor = torch.empty(0, dtype=torch.float32, device=self.pipeline_engine.device)
-
-        # Convert to tensors, handling empty case
-        if len(norms) > 0:
-            norms_tensor = torch.tensor(norms, dtype=torch.float32, device=self.pipeline_engine.device)
-        else:
-            norms_tensor = torch.empty(0, dtype=torch.float32, device=self.pipeline_engine.device)
-
-        # Only return weight decay if regularization was applied
-        if lora_weight_decay > 0:
-            # Convert to tensors, handling empty case
-            if len(weight_decay) > 0:
-                weight_decay_tensor = torch.tensor(weight_decay, dtype=torch.float32, device=self.pipeline_engine.device)
-            else:
-                weight_decay_tensor = torch.empty(0, dtype=torch.float32, device=self.pipeline_engine.device)
-            return {
-                'norms': norms_tensor,
-                'orthogonality': orthogonality_tensor,
-                'weight_decay': weight_decay_tensor
-            }
-        else:
-            return {
-                'norms': norms_tensor,
-                'orthogonality': orthogonality_tensor
-            }
+        return self._aggregate_statistics(local_stats)
 
     def _aggregate_statistics(self, local_stats):
         """Aggregate LoRA and Control Adapter statistics across pipeline stages and compute global statistics.
@@ -282,7 +116,7 @@ class Regularizer:
             - Empty tensors contribute neutral elements via sentinels for MIN/MAX
 
         Output:
-            For each key in local_stats (e.g., 'norms', 'orthogonality', 'weight_decay'),
+            For each key in local_stats (e.g., 'norms', 'weight_decay'),
             returns three scalar entries:
                 - '{key}_avg'
                 - '{key}_min'


### PR DESCRIPTION
This PR replaces the spectral decomposition architecture (`Q diag(λ) Q^T` with log-parameterized eigenvalues) with a standard LoRA-style factorization (`W = B @ A`).

**Rationale:** The orthogonality constraints required to maintain `Q^T Q ≈ I` introduced significant complexity without commensurate gains. The Newton-step regularization (`control_adapter_gamma`) and log-parameterization (`control_S`) created a brittle training dynamic that was difficult to tune and debug.

**New Approach:** Control Adapters now use a simple multiplicative residual transformation `(I + W) × delta` where `W = B @ A`. For bidirectional control, we approximate the inverse `(I + W)^{-1}` via first-order Neumann series (`I - W`), which converges reliably when maintaining `‖W‖₂ < 0.25` through standard L2 weight decay on the composite matrix.

**Benefits:**
- **Reduced complexity:** Eliminates orthogonality maintenance and special parameter initializations
- **Better stability:** Standard LoRA regularization techniques apply directly
- **Maintained functionality:** Bidirectional control preserved via mathematically sound approximation
- **Easier analysis:** Standard matrix norms (spectral, Frobenius) replace eigenvalue-based diagnostics

**Breaking Change:** This is a breaking architectural change. Existing Control Adapter checkpoints using `control_Q` and `control_S` parameters are incompatible and must be retrained. The `control_adapter_gamma` configuration parameter has been removed; use `lora_weight_decay` (typically 1.0–20.0) to control spectral norm bounds.
